### PR TITLE
SDK 3.3.0-beta is added. 

### DIFF
--- a/src/ConsoleConnector/Commands/GetExchangeCommand.cs
+++ b/src/ConsoleConnector/Commands/GetExchangeCommand.cs
@@ -13,11 +13,12 @@ namespace Autodesk.DataExchange.ConsoleApp.Commands
         public GetExchangeCommand(ConsoleAppHelper consoleAppHelper) : base(consoleAppHelper)
         {
             Name = "GetExchange";
-            Description = "Get exchange and download as a STEP file.";
+            Description = "Get exchange and download as a [STEP(Default)/OBJ] file.";
             Options = new List<CommandOption>
             {
                 new ExchangeId(),
-                new CollectionId()
+                new CollectionId(),
+                new ExchangeFileFormat()
             };
         }
 
@@ -47,9 +48,18 @@ namespace Autodesk.DataExchange.ConsoleApp.Commands
 
             var exchangeId = GetOption<ExchangeId>().Value;
             var collectionId = GetOption<CollectionId>().Value;
+            var exchangeDownLoadFileFormat = GetOption<ExchangeFileFormat>().Value?.ToUpper()?.Trim();
+            if (string.IsNullOrEmpty(exchangeDownLoadFileFormat))
+                exchangeDownLoadFileFormat = "STEP";
+            if(exchangeDownLoadFileFormat!="STEP" &&
+                exchangeDownLoadFileFormat != "OBJ")
+            {
+                Console.WriteLine("File format for exchange is not correct. Please specify STEP/OBJ or keep it blank.");
+                return false;
+            }
 
             Console.WriteLine("Downloading exchange...");
-            var status = await ConsoleAppHelper.GetExchange(exchangeId, collectionId, hubId, region);
+            var status = await ConsoleAppHelper.GetExchange(exchangeId, collectionId, hubId, region, exchangeDownLoadFileFormat);
             if (status == null || string.IsNullOrEmpty(status.Item1))
             {
                 Console.WriteLine("Downloading exchange is failed.");
@@ -58,6 +68,22 @@ namespace Autodesk.DataExchange.ConsoleApp.Commands
 
             Console.WriteLine("Exchange downloaded.");
             Console.WriteLine("Exchange STEP file: "+status.Item1);
+            return true;
+        }
+
+        public override bool ValidateOptions()
+        {
+            foreach (var option in this.Options)
+            {
+                if(option is ExchangeFileFormat)
+                {
+                    continue;
+                }
+                if (option.IsValid() == false)
+                {
+                    return false;
+                }
+            }
             return true;
         }
     }

--- a/src/ConsoleConnector/Commands/HelpCommand.cs
+++ b/src/ConsoleConnector/Commands/HelpCommand.cs
@@ -46,6 +46,8 @@ namespace Autodesk.DataExchange.ConsoleApp.Commands
                 Console.WriteLine();
                 Console.Write(command.Description + "\n");
                 var allOptions = string.Join(" ", command.Options.Select(n => "[" + n.GetType().Name.Replace("Option", "") + "]"));
+                if (command is GetExchangeCommand)
+                    allOptions += "(Optional)";
                 Console.Write(command.Name.ToUpper() + " " + allOptions + "\n");
                 var maxNameLength = command.Options.Count > 0 ? command.Options.Max(n => n.GetType().Name.Replace("Option", "").Length) + 5 : 0;
                 var maxDescriptionLength = command.Options.Count > 0 ? command.Options.Max(n => n.Description.Length) + 5 : 0;

--- a/src/ConsoleConnector/Commands/Options/ExchangeFileFormat.cs
+++ b/src/ConsoleConnector/Commands/Options/ExchangeFileFormat.cs
@@ -1,0 +1,20 @@
+﻿namespace Autodesk.DataExchange.ConsoleApp.Commands.Options
+{
+    /// <summary>
+    /// ElementId command option.
+    /// </summary>
+    /// <seealso cref="CommandOption" />
+    internal class ExchangeFileFormat : CommandOption
+    {
+
+        public ExchangeFileFormat()
+        {
+            this.Description = "Specify the exchange download file format.(STEP[Default],OBJ)";
+        }
+
+        public override string ToString()
+        {
+            return "ExchangeFileFormat[" + Description + "](Optional)";
+        }
+    }
+}

--- a/src/ConsoleConnector/ConsoleConnector.csproj
+++ b/src/ConsoleConnector/ConsoleConnector.csproj
@@ -265,6 +265,7 @@
     <Compile Include="Commands\AddTypeParamCommand.cs" />
     <Compile Include="Commands\Command.cs" />
     <Compile Include="Commands\GetExchangeCommand.cs" />
+    <Compile Include="Commands\Options\ExchangeFileFormat.cs" />
     <Compile Include="Commands\Options\ExchangeId.cs" />
     <Compile Include="Commands\Options\CollectionId.cs" />
     <Compile Include="Commands\Options\CommandOption.cs" />

--- a/src/ConsoleConnector/ConsoleConnector.csproj
+++ b/src/ConsoleConnector/ConsoleConnector.csproj
@@ -57,44 +57,44 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autodesk.DataExchange, Version=3.1.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.3.1.0-beta\lib\net48\Autodesk.DataExchange.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange, Version=3.3.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.3.3.0-beta\lib\net48\Autodesk.DataExchange.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Authentication, Version=3.1.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.3.1.0-beta\lib\net48\Autodesk.DataExchange.Authentication.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Authentication, Version=3.3.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.3.3.0-beta\lib\net48\Autodesk.DataExchange.Authentication.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.ContractProvider, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Autodesk.DataExchange.3.1.0-beta\lib\net48\Autodesk.DataExchange.ContractProvider.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.ContractProvider, Version=3.3.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.3.3.0-beta\lib\net48\Autodesk.DataExchange.ContractProvider.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Core, Version=3.1.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.3.1.0-beta\lib\net48\Autodesk.DataExchange.Core.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Core, Version=3.3.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.3.3.0-beta\lib\net48\Autodesk.DataExchange.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Exceptions, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Autodesk.DataExchange.3.1.0-beta\lib\net48\Autodesk.DataExchange.Exceptions.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Exceptions, Version=3.3.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.3.3.0-beta\lib\net48\Autodesk.DataExchange.Exceptions.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Extensions.HostingProvider, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Autodesk.DataExchange.3.1.0-beta\lib\net48\Autodesk.DataExchange.Extensions.HostingProvider.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Extensions.HostingProvider, Version=3.3.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.3.3.0-beta\lib\net48\Autodesk.DataExchange.Extensions.HostingProvider.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Extensions.Logging.File, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Autodesk.DataExchange.3.1.0-beta\lib\net48\Autodesk.DataExchange.Extensions.Logging.File.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Extensions.Logging.File, Version=3.3.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.3.3.0-beta\lib\net48\Autodesk.DataExchange.Extensions.Logging.File.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Extensions.Storage.File, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Autodesk.DataExchange.3.1.0-beta\lib\net48\Autodesk.DataExchange.Extensions.Storage.File.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Extensions.Storage.File, Version=3.3.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.3.3.0-beta\lib\net48\Autodesk.DataExchange.Extensions.Storage.File.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Metrics, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Autodesk.DataExchange.3.1.0-beta\lib\net48\Autodesk.DataExchange.Metrics.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Metrics, Version=3.3.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.3.3.0-beta\lib\net48\Autodesk.DataExchange.Metrics.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.OpenAPI, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Autodesk.DataExchange.3.1.0-beta\lib\net48\Autodesk.DataExchange.OpenAPI.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.OpenAPI, Version=3.3.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.3.3.0-beta\lib\net48\Autodesk.DataExchange.OpenAPI.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Resiliency, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Autodesk.DataExchange.3.1.0-beta\lib\net48\Autodesk.DataExchange.Resiliency.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Resiliency, Version=3.3.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.3.3.0-beta\lib\net48\Autodesk.DataExchange.Resiliency.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Schemas, Version=3.1.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.3.1.0-beta\lib\net48\Autodesk.DataExchange.Schemas.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Schemas, Version=3.3.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.3.3.0-beta\lib\net48\Autodesk.DataExchange.Schemas.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.SourceProvider, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Autodesk.DataExchange.3.1.0-beta\lib\net48\Autodesk.DataExchange.SourceProvider.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.SourceProvider, Version=3.3.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.3.3.0-beta\lib\net48\Autodesk.DataExchange.SourceProvider.dll</HintPath>
     </Reference>
     <Reference Include="Autodesk.Extensions.Http.ForgeRetry, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Autodesk.Extensions.Http.ForgeRetry.8.0.0\lib\netstandard2.0\Autodesk.Extensions.Http.ForgeRetry.dll</HintPath>
@@ -102,8 +102,8 @@
     <Reference Include="Autodesk.Forge, Version=1.9.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Autodesk.Forge.1.9.8\lib\net48\Autodesk.Forge.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.GeometryPrimitives, Version=0.5.4.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\geometry-primitives-sdk-win-release-x64.0.5.4\lib\netstandard2.0\Autodesk.GeometryPrimitives.dll</HintPath>
+    <Reference Include="Autodesk.GeometryPrimitives, Version=0.5.7.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\geometry-primitives-sdk-win-release-x64.0.5.7\lib\netstandard2.0\Autodesk.GeometryPrimitives.dll</HintPath>
     </Reference>
     <Reference Include="ForgeParametersCLR, Version=1.0.1.0, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>..\..\packages\ForgeParameters-csharp_win_release_intel64_v142.1.0.1\lib\net48\ForgeParametersCLR.dll</HintPath>
@@ -358,9 +358,9 @@
     <Error Condition="!Exists('..\..\packages\ForgeUnits-csharp_win_release_intel64_v142.4.0.3\build\ForgeUnits-csharp_win_release_intel64_v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ForgeUnits-csharp_win_release_intel64_v142.4.0.3\build\ForgeUnits-csharp_win_release_intel64_v142.targets'))" />
     <Error Condition="!Exists('..\..\packages\ForgeParameters-csharp_win_release_intel64_v142.1.0.1\build\ForgeParameters-csharp_win_release_intel64_v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ForgeParameters-csharp_win_release_intel64_v142.1.0.1\build\ForgeParameters-csharp_win_release_intel64_v142.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Autodesk.DataExchange.3.1.0-beta\build\Autodesk.DataExchange.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Autodesk.DataExchange.3.1.0-beta\build\Autodesk.DataExchange.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Autodesk.DataExchange.3.3.0-beta\build\Autodesk.DataExchange.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Autodesk.DataExchange.3.3.0-beta\build\Autodesk.DataExchange.targets'))" />
   </Target>
   <Import Project="..\..\packages\ForgeParameters-csharp_win_release_intel64_v142.1.0.1\build\ForgeParameters-csharp_win_release_intel64_v142.targets" Condition="Exists('..\..\packages\ForgeParameters-csharp_win_release_intel64_v142.1.0.1\build\ForgeParameters-csharp_win_release_intel64_v142.targets')" />
   <Import Project="..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets" Condition="Exists('..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets')" />
-  <Import Project="..\..\packages\Autodesk.DataExchange.3.1.0-beta\build\Autodesk.DataExchange.targets" Condition="Exists('..\..\packages\Autodesk.DataExchange.3.1.0-beta\build\Autodesk.DataExchange.targets')" />
+  <Import Project="..\..\packages\Autodesk.DataExchange.3.3.0-beta\build\Autodesk.DataExchange.targets" Condition="Exists('..\..\packages\Autodesk.DataExchange.3.3.0-beta\build\Autodesk.DataExchange.targets')" />
 </Project>

--- a/src/ConsoleConnector/Helper/ConsoleAppHelper.cs
+++ b/src/ConsoleConnector/Helper/ConsoleAppHelper.cs
@@ -243,8 +243,8 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
         public async Task<bool> SyncExchange(DataExchangeIdentifier dataExchangeIdentifier, ExchangeDetails exchangeDetails, ExchangeData exchangeData)
         {
             await Client.SyncExchangeDataAsync(dataExchangeIdentifier, exchangeData);
-            await Client.GenerateViewableAsync(exchangeDetails.DisplayName, exchangeDetails.ExchangeID,
-                exchangeDetails.CollectionID, exchangeDetails.FileUrn);
+            await Client.GenerateViewableAsync(exchangeDetails.ExchangeID,
+                exchangeDetails.CollectionID);
             return true;
         }
 
@@ -301,9 +301,9 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
             return exchangeDetails.DisplayName;
         }
 
-        public async Task<Tuple<string,bool>> GetExchange(string exchangeId, string collectionId, string hubId, string hubRegion)
+        public async Task<Tuple<string,bool>> GetExchange(string exchangeId, string collectionId, string hubId, string hubRegion, string fileFormat)
         {
-            var stepFile = string.Empty;
+            var exchangeFile = string.Empty;
             var isUpdated = false;
 
             try
@@ -366,8 +366,11 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
 
                     await Task.WhenAll(geometryResults).ConfigureAwait(false);
 
-                    //Get Geometry of whole exchange file as STEP
-                    stepFile =  Client.DownloadCompleteExchangeAsSTEP(data.ExchangeData.ExchangeID);
+                    //Get Geometry of whole exchange file
+                    if(fileFormat == "OBJ")
+                        exchangeFile = Client.DownloadCompleteExchangeAsOBJ(data.ExchangeData.ExchangeID, collectionId);
+                    else
+                        exchangeFile =  Client.DownloadCompleteExchangeAsSTEP(data.ExchangeData.ExchangeID);
                     isUpdated = false;
                 }
                 else
@@ -414,8 +417,11 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
                     await Task.WhenAll(geometryResults).ConfigureAwait(false);
 
 
-                    //Get Geometry of whole exchange file as STEP
-                    stepFile = Client.DownloadCompleteExchangeAsSTEP(data.ExchangeData.ExchangeID);
+                    //Get Geometry of whole exchange file
+                    if (fileFormat == "OBJ")
+                        exchangeFile = Client.DownloadCompleteExchangeAsOBJ(data.ExchangeData.ExchangeID,collectionId);
+                    else 
+                        exchangeFile = Client.DownloadCompleteExchangeAsSTEP(data.ExchangeData.ExchangeID);
                     isUpdated = true;
                 }
 
@@ -427,7 +433,7 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
                 Console.WriteLine(e);
             }
 
-            return new Tuple<string, bool>(stepFile, isUpdated);
+            return new Tuple<string, bool>(exchangeFile, isUpdated);
         }
     }
 }

--- a/src/ConsoleConnector/Interfaces/IConsoleAppHelper.cs
+++ b/src/ConsoleConnector/Interfaces/IConsoleAppHelper.cs
@@ -31,7 +31,7 @@ namespace Autodesk.DataExchange.ConsoleApp.Interfaces
         GeometryHelper GetGeometryHelper();
         ParameterHelper GetParameterHelper();
 
-        Task<Tuple<string, bool>> GetExchange(string exchangeId, string collectionId, string hubId, string hubRegion);
+        Task<Tuple<string, bool>> GetExchange(string exchangeId, string collectionId, string hubId, string hubRegion,string fileFormat);
 
     }
 }

--- a/src/ConsoleConnector/packages.config
+++ b/src/ConsoleConnector/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autodesk.DataExchange" version="3.1.0-beta" targetFramework="net48" />
+  <package id="Autodesk.DataExchange" version="3.3.0-beta" targetFramework="net48" />
   <package id="Autodesk.Extensions.Http.ForgeRetry" version="8.0.0" targetFramework="net48" />
   <package id="Autodesk.Forge" version="1.9.8" targetFramework="net48" />
   <package id="ForgeParameters-csharp_win_release_intel64_v142" version="1.0.1" targetFramework="net48" />
   <package id="ForgeUnits-csharp_win_release_intel64_v142" version="4.0.3" targetFramework="net48" />
-  <package id="geometry-primitives-sdk-win-release-x64" version="0.5.4" targetFramework="net48" />
+  <package id="geometry-primitives-sdk-win-release-x64" version="0.5.7" targetFramework="net48" />
   <package id="Google.Protobuf" version="3.19.4" targetFramework="net48" />
   <package id="IdentityModel" version="5.0.1" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />


### PR DESCRIPTION
### * Non breaking changes are added *

**GetExchange** command now having a optional parameter called ### ExchangeFileFormat.
Right only **STEP(Default)** and **OBJ** file format is supported. **ExchangeFileFormat** parameter is optional parameter. **STEP** and **OBJ** options are valid options and apart from this options will be considered as wrong file format. User can keep this parameter as a blank so default **STEP** format is considered. 
![image](https://github.com/autodesk-platform-services/aps-dataexchange-console/assets/143083177/4a4e2c78-7a7a-4d58-9d06-a2a26122015f)
