### PR TITLE
Fixed old geometry primitives version

### DIFF
--- a/src/ConsoleConnector/ConsoleConnector.csproj
+++ b/src/ConsoleConnector/ConsoleConnector.csproj
@@ -102,8 +102,8 @@
     <Reference Include="Autodesk.Forge, Version=1.9.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Autodesk.Forge.1.9.8\lib\net48\Autodesk.Forge.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.GeometryPrimitives, Version=0.7.5.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\geometry-primitives-sdk-win-release-x64.0.7.5\lib\net48\Autodesk.GeometryPrimitives.dll</HintPath>
+    <Reference Include="Autodesk.GeometryPrimitives, Version=0.7.6.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\geometry-primitives-sdk-win-release-x64.0.7.6\lib\net48\Autodesk.GeometryPrimitives.dll</HintPath>
     </Reference>
     <Reference Include="CBOR, Version=4.5.2.0, Culture=neutral, PublicKeyToken=9cd62db60ea5554c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\PeterO.Cbor.4.5.2\lib\net40\CBOR.dll</HintPath>

--- a/src/ConsoleConnector/packages.config
+++ b/src/ConsoleConnector/packages.config
@@ -5,7 +5,7 @@
   <package id="Autodesk.Forge" version="1.9.8" targetFramework="net48" />
   <package id="ForgeParameters-csharp_win_release_intel64_v140" version="3.0.6" targetFramework="net48" />
   <package id="ForgeUnits-csharp_win_release_intel64_v140" version="5.1.4" targetFramework="net48" />
-  <package id="geometry-primitives-sdk-win-release-x64" version="0.7.5" targetFramework="net48" />
+  <package id="geometry-primitives-sdk-win-release-x64" version="0.7.6" targetFramework="net48" />
   <package id="Google.Protobuf" version="3.19.4" targetFramework="net48" />
   <package id="IdentityModel" version="5.0.1" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />

--- a/test/ConsoleConnector_Test/ConsoleConnector_Test.csproj
+++ b/test/ConsoleConnector_Test/ConsoleConnector_Test.csproj
@@ -102,8 +102,8 @@
     <Reference Include="Autodesk.Forge, Version=1.9.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Autodesk.Forge.1.9.8\lib\net48\Autodesk.Forge.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.GeometryPrimitives, Version=0.7.5.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\geometry-primitives-sdk-win-release-x64.0.7.5\lib\net48\Autodesk.GeometryPrimitives.dll</HintPath>
+    <Reference Include="Autodesk.GeometryPrimitives, Version=0.7.6.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\geometry-primitives-sdk-win-release-x64.0.7.6\lib\net48\Autodesk.GeometryPrimitives.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Core.5.1.1\lib\net462\Castle.Core.dll</HintPath>

--- a/test/ConsoleConnector_Test/packages.config
+++ b/test/ConsoleConnector_Test/packages.config
@@ -8,7 +8,7 @@
   <package id="ForgeParameters-csharp_win_release_intel64_v142" version="1.0.1" targetFramework="net48" />
   <package id="ForgeUnits-csharp_win_release_intel64_v140" version="5.1.4" targetFramework="net48" />
   <package id="ForgeUnits-csharp_win_release_intel64_v142" version="4.0.3" targetFramework="net48" />
-  <package id="geometry-primitives-sdk-win-release-x64" version="0.7.5" targetFramework="net48" />
+  <package id="geometry-primitives-sdk-win-release-x64" version="0.7.6" targetFramework="net48" />
   <package id="Google.Protobuf" version="3.19.4" targetFramework="net48" />
   <package id="IdentityModel" version="5.0.1" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />


### PR DESCRIPTION
Updates the geometry primitives package to the correct version shipped with SDK 5.1.1-beta