### PR TITLE
Updated SetFolder command with ACC folder URL. 

### DIFF
--- a/src/ConsoleConnector/Commands/HelpCommand.cs
+++ b/src/ConsoleConnector/Commands/HelpCommand.cs
@@ -48,6 +48,11 @@ namespace Autodesk.DataExchange.ConsoleApp.Commands
                 var allOptions = string.Join(" ", command.Options.Select(n => "[" + n.GetType().Name.Replace("Option", "") + "]"));
                 if (command is GetExchangeCommand)
                     allOptions += "(Optional)";
+
+                if(command is SetFolderCommand)
+                {
+                    allOptions += "\nSETFOLDER [FolderUrl]";
+                }
                 Console.Write(command.Name.ToUpper() + " " + allOptions + "\n");
                 var maxNameLength = command.Options.Count > 0 ? command.Options.Max(n => n.GetType().Name.Replace("Option", "").Length) + 5 : 0;
                 var maxDescriptionLength = command.Options.Count > 0 ? command.Options.Max(n => n.Description.Length) + 5 : 0;
@@ -58,6 +63,16 @@ namespace Autodesk.DataExchange.ConsoleApp.Commands
 
                     var str = string.Format("|{0,-" + maxNameLength + "} | {1,-" + maxDescriptionLength + "} |", typeName, option.Description);
                     Console.WriteLine(str);
+                }
+
+                if (command is SetFolderCommand)
+                {
+                    FolderUrl option = new FolderUrl();
+                    var typeName = option.GetType().Name;
+                    typeName = typeName.Replace("Option", "");
+
+                    var str = string.Format("|{0,-" + maxNameLength + "} | {1,-" + maxDescriptionLength + "} |", typeName, option.Description);
+                    Console.WriteLine(str); Console.WriteLine();
                 }
                 Console.WriteLine();
 

--- a/src/ConsoleConnector/Commands/Options/FolderUrl.cs
+++ b/src/ConsoleConnector/Commands/Options/FolderUrl.cs
@@ -1,0 +1,19 @@
+﻿namespace Autodesk.DataExchange.ConsoleApp.Commands.Options
+{
+    /// <summary>
+    /// FolderUrn command option.
+    /// </summary>
+    /// <seealso cref="CommandOption" />
+    internal class FolderUrl : CommandOption
+    {
+        public FolderUrl()
+        {
+            this.Description = "Specify folder URL for exchange creation, etc.";
+        }
+
+        public override string ToString()
+        {
+            return "FolderURL[" + Description + "](Optional)";
+        }
+    }
+}

--- a/src/ConsoleConnector/Commands/SetFolderCommand.cs
+++ b/src/ConsoleConnector/Commands/SetFolderCommand.cs
@@ -21,9 +21,9 @@ namespace Autodesk.DataExchange.ConsoleApp.Commands
             Options = new List<CommandOption>
             {
                 new HubId(),
-                new Region(), 
-                new ProjectUrn(), 
-                new FolderUrn()
+                new Region(),
+                new ProjectUrn(),
+                new FolderUrn(),
             };
         }
 
@@ -38,6 +38,11 @@ namespace Autodesk.DataExchange.ConsoleApp.Commands
 
         public override Task<bool> Execute()
         {
+            var check = this.GetOption<HubId>().Value;
+            if (check.Contains("http"))
+            {
+                return Execute(check);
+            }
             if (this.ValidateOptions() == false)
             {
                 Console.WriteLine("Invalid inputs!!!");
@@ -48,6 +53,38 @@ namespace Autodesk.DataExchange.ConsoleApp.Commands
             var projectUrn = this.GetOption<ProjectUrn>();
             var folderUrn = this.GetOption<FolderUrn>();
             ConsoleAppHelper.SetFolder(region.Value,hubId.Value,projectUrn.Value,folderUrn.Value);
+            Console.WriteLine("Default folder set!!!");
+            return Task.FromResult(true);
+        }
+
+        private Task<bool> Execute(string folderUrl)
+        {
+            var projectUrn = "b." + folderUrl.ToString().Split('/')[6].Split('?')[0];
+            var folderUrn = folderUrl.ToString().Split('/')[6].Split('?')[1].Split('&')[0].Split('=')[1].Replace("%3A", ":");
+
+            ConsoleAppHelper.GetHubId(projectUrn, out string hubId);
+            if (string.IsNullOrEmpty(hubId))
+            {
+                Console.WriteLine("Invalid FolderUrl!!!");
+                return Task.FromResult(false);
+            }
+            ConsoleAppHelper.GetRegion(hubId, out string region);
+            if(string.IsNullOrEmpty(region)) 
+            {
+                Console.WriteLine("Invalid FolderUrl!!!");
+                return Task.FromResult(false);
+            }
+            if(string.IsNullOrEmpty(folderUrn))
+            {
+                Console.WriteLine("Invalid FolderUrl!!!");
+                return Task.FromResult(false);
+            }
+            if(string.IsNullOrEmpty(projectUrn))
+            {
+                Console.WriteLine("Invalid FolderUrl!!!");
+                return Task.FromResult(false);
+            }
+            ConsoleAppHelper.SetFolder(region, hubId, projectUrn, folderUrn);
             Console.WriteLine("Default folder set!!!");
             return Task.FromResult(true);
         }

--- a/src/ConsoleConnector/ConsoleConnector.csproj
+++ b/src/ConsoleConnector/ConsoleConnector.csproj
@@ -432,6 +432,7 @@
     <Compile Include="Commands\HelpCommand.cs" />
     <Compile Include="Commands\Options\ElementId.cs" />
     <Compile Include="Commands\Options\ExchangeTitle.cs" />
+    <Compile Include="Commands\Options\FolderUrl.cs" />
     <Compile Include="Commands\Options\FolderUrn.cs" />
     <Compile Include="Commands\Options\HelpCommand.cs" />
     <Compile Include="Commands\Options\HubId.cs" />

--- a/src/ConsoleConnector/Helper/ConsoleAppHelper.cs
+++ b/src/ConsoleConnector/Helper/ConsoleAppHelper.cs
@@ -218,7 +218,6 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
         {
             Commands.Add(new GetExchangeCommand(this));
             Commands.Add(new SetFolderCommand(this));
-            Commands.Add(new SetFolderUrlCommand(this));
             Commands.Add(new CreateExchangeCommand(this));
             Commands.Add(new CreateBrepCommand(this));
             Commands.Add(new CreateMeshCommand(this));

--- a/src/ConsoleConnector/Helper/ConsoleAppHelper.cs
+++ b/src/ConsoleConnector/Helper/ConsoleAppHelper.cs
@@ -77,6 +77,25 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
             _exchangeData[exchangeTitle] = exchangeData;
         }
 
+        public async Task<string> GetRegionAsync(string hubId)
+        {
+            return await Client.SDKOptions.HostingProvider.GetRegionAsync(hubId);
+        }
+        public async Task<string> GetHubIdAsync(string projectUrn)
+        {
+            return await Client.GetHubIdAsync(projectUrn);
+        }
+
+        public void GetHubId(string projectUrn, out string hubId)
+        {
+            hubId = GetHubIdAsync(projectUrn).Result;
+        }
+
+        public void GetRegion(string hubId, out string region)
+        {
+            region = GetRegionAsync(hubId).Result;
+        }
+
         public ExchangeData GetExchangeData(string exchangeTitle)
         {
             if (_exchangeData.TryGetValue(exchangeTitle, out _) == false)
@@ -199,6 +218,7 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
         {
             Commands.Add(new GetExchangeCommand(this));
             Commands.Add(new SetFolderCommand(this));
+            Commands.Add(new SetFolderUrlCommand(this));
             Commands.Add(new CreateExchangeCommand(this));
             Commands.Add(new CreateBrepCommand(this));
             Commands.Add(new CreateMeshCommand(this));

--- a/src/ConsoleConnector/Interfaces/IConsoleAppHelper.cs
+++ b/src/ConsoleConnector/Interfaces/IConsoleAppHelper.cs
@@ -24,7 +24,8 @@ namespace Autodesk.DataExchange.ConsoleApp.Interfaces
         void BuildCommands();
         Command GetCommand(string input);
         Task<ExchangeDetails> CreateExchange(string exchangeTitle);
-
+        void GetHubId(string projectUrn, out string hubId);
+        void GetRegion(string hubId, out string region);
         Task<bool> SyncExchange(DataExchangeIdentifier dataExchangeIdentifier,ExchangeDetails exchangeDetails, ExchangeData exchangeData);
 
         Client GetClient();


### PR DESCRIPTION
SetFolder command now support ACC folder URL which will extract the necessary details such as FolderURN,ProjectURN,HubId and Region. 
User just need to navigate to the ACC folder copy the URL and provide it to SetFolder command.
Example:
`SetFolder ACC_URL.`
