### PR TITLE
Remove Outdated Reference in ConnectorTest Packages.config

### DIFF
--- a/test/ConsoleConnector_Test/packages.config
+++ b/test/ConsoleConnector_Test/packages.config
@@ -5,9 +5,7 @@
   <package id="Autodesk.Forge" version="1.9.8" targetFramework="net48" />
   <package id="Castle.Core" version="5.1.1" targetFramework="net48" />
   <package id="ForgeParameters-csharp_win_release_intel64_v140" version="3.0.6" targetFramework="net48" />
-  <package id="ForgeParameters-csharp_win_release_intel64_v142" version="1.0.1" targetFramework="net48" />
   <package id="ForgeUnits-csharp_win_release_intel64_v140" version="5.1.4" targetFramework="net48" />
-  <package id="ForgeUnits-csharp_win_release_intel64_v142" version="4.0.3" targetFramework="net48" />
   <package id="geometry-primitives-sdk-win-release-x64" version="0.7.6" targetFramework="net48" />
   <package id="Google.Protobuf" version="3.19.4" targetFramework="net48" />
   <package id="IdentityModel" version="5.0.1" targetFramework="net48" />


### PR DESCRIPTION
These nugets are not part of the sdk release bundle, and the newly updated references are already present, so removing these nugets will enable successful builds with no hassle. 