### PR TITLE
Updated to DX SDK 5.2.2-beta

### DIFF
--- a/src/ConsoleConnector/Commands/CreateMeshCommand.cs
+++ b/src/ConsoleConnector/Commands/CreateMeshCommand.cs
@@ -49,6 +49,7 @@ namespace Autodesk.DataExchange.ConsoleApp.Commands
 
             var elementDataModel = ElementDataModel.Create(ConsoleAppHelper.GetClient(), exchangeData);
             var mesh = ConsoleAppHelper.GetGeometryHelper().CreateMesh(elementDataModel);
+            var meshApiObject = ConsoleAppHelper.GetGeometryHelper().CreateMeshThroughMeshApi(elementDataModel);
             ConsoleAppHelper.AddExchangeData(exchangeTitle.Value, elementDataModel.ExchangeData);
             ConsoleAppHelper.SetExchangeUpdated(exchangeTitle.Value, true);
             Console.WriteLine("Element Id: " + mesh.Id);
@@ -56,6 +57,12 @@ namespace Autodesk.DataExchange.ConsoleApp.Commands
             Console.WriteLine("Category: " + mesh.Category);
             Console.WriteLine("Family: " + mesh.Family);
             Console.WriteLine("Type: " + mesh.Type);
+            Console.WriteLine();
+            Console.WriteLine("Element Id: " + meshApiObject.Id);
+            Console.WriteLine("Element Name: " + meshApiObject.Name);
+            Console.WriteLine("Category: " + meshApiObject.Category);
+            Console.WriteLine("Family: " + meshApiObject.Family);
+            Console.WriteLine("Type: " + meshApiObject.Type);
             Console.WriteLine();
             return Task.FromResult(true);
         }

--- a/src/ConsoleConnector/Commands/HelpCommand.cs
+++ b/src/ConsoleConnector/Commands/HelpCommand.cs
@@ -49,7 +49,7 @@ namespace Autodesk.DataExchange.ConsoleApp.Commands
                 if (command is GetExchangeCommand)
                     allOptions += "(Optional)";
 
-                if(command is SetFolderCommand)
+                if (command is SetFolderCommand)
                 {
                     allOptions += "\nSETFOLDER [FolderUrl]";
                 }

--- a/src/ConsoleConnector/Commands/SetFolderCommand.cs
+++ b/src/ConsoleConnector/Commands/SetFolderCommand.cs
@@ -69,17 +69,17 @@ namespace Autodesk.DataExchange.ConsoleApp.Commands
                 return Task.FromResult(false);
             }
             ConsoleAppHelper.GetRegion(hubId, out string region);
-            if(string.IsNullOrEmpty(region)) 
+            if (string.IsNullOrEmpty(region)) 
             {
                 Console.WriteLine("Invalid FolderUrl!!!");
                 return Task.FromResult(false);
             }
-            if(string.IsNullOrEmpty(folderUrn))
+            if (string.IsNullOrEmpty(folderUrn))
             {
                 Console.WriteLine("Invalid FolderUrl!!!");
                 return Task.FromResult(false);
             }
-            if(string.IsNullOrEmpty(projectUrn))
+            if (string.IsNullOrEmpty(projectUrn))
             {
                 Console.WriteLine("Invalid FolderUrl!!!");
                 return Task.FromResult(false);

--- a/src/ConsoleConnector/ConsoleConnector.csproj
+++ b/src/ConsoleConnector/ConsoleConnector.csproj
@@ -57,44 +57,44 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autodesk.DataExchange, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Authentication, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.Authentication.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Authentication, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Authentication.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.ContractProvider, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.ContractProvider.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.ContractProvider, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.ContractProvider.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Core, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.Core.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Core, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Exceptions, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.Exceptions.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Exceptions, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Exceptions.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Extensions.HostingProvider, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.Extensions.HostingProvider.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Extensions.HostingProvider, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Extensions.HostingProvider.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Extensions.Logging.File, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.Extensions.Logging.File.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Extensions.Logging.File, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Extensions.Logging.File.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Extensions.Storage.File, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.Extensions.Storage.File.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Extensions.Storage.File, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Extensions.Storage.File.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Metrics, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.Metrics.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Metrics, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Metrics.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.OpenAPI, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.OpenAPI.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.OpenAPI, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.OpenAPI.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Resiliency, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.Resiliency.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Resiliency, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Resiliency.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Schemas, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.Schemas.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Schemas, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Schemas.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.SourceProvider, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.SourceProvider.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.SourceProvider, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.SourceProvider.dll</HintPath>
     </Reference>
     <Reference Include="Autodesk.Extensions.Http.ForgeRetry, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Autodesk.Extensions.Http.ForgeRetry.8.0.0\lib\netstandard2.0\Autodesk.Extensions.Http.ForgeRetry.dll</HintPath>
@@ -104,6 +104,15 @@
     </Reference>
     <Reference Include="Autodesk.GeometryPrimitives, Version=0.7.6.0, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>..\..\packages\geometry-primitives-sdk-win-release-x64.0.7.6\lib\net48\Autodesk.GeometryPrimitives.dll</HintPath>
+    </Reference>
+    <Reference Include="Autodesk.GeometryPrimitives.Data, Version=0.7.10.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.1\lib\net48\Autodesk.GeometryPrimitives.Data.dll</HintPath>
+    </Reference>
+    <Reference Include="Autodesk.GeometryUtilities.BRepAPI, Version=0.0.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.1\lib\net48\Autodesk.GeometryUtilities.BRepAPI.dll</HintPath>
+    </Reference>
+    <Reference Include="Autodesk.GeometryUtilities.MeshAPI, Version=0.0.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.1\lib\net48\Autodesk.GeometryUtilities.MeshAPI.dll</HintPath>
     </Reference>
     <Reference Include="CBOR, Version=4.5.2.0, Culture=neutral, PublicKeyToken=9cd62db60ea5554c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\PeterO.Cbor.4.5.2\lib\net40\CBOR.dll</HintPath>
@@ -517,10 +526,10 @@
     <Error Condition="!Exists('..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets'))" />
     <Error Condition="!Exists('..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets'))" />
     <Error Condition="!Exists('..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Autodesk.DataExchange.5.1.1-beta\build\Autodesk.DataExchange.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Autodesk.DataExchange.5.1.1-beta\build\Autodesk.DataExchange.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Autodesk.DataExchange.5.2.1-beta\build\Autodesk.DataExchange.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Autodesk.DataExchange.5.2.1-beta\build\Autodesk.DataExchange.targets'))" />
   </Target>
   <Import Project="..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets" Condition="Exists('..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets')" />
   <Import Project="..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets" Condition="Exists('..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets')" />
   <Import Project="..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets" Condition="Exists('..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets')" />
-  <Import Project="..\..\packages\Autodesk.DataExchange.5.1.1-beta\build\Autodesk.DataExchange.targets" Condition="Exists('..\..\packages\Autodesk.DataExchange.5.1.1-beta\build\Autodesk.DataExchange.targets')" />
+  <Import Project="..\..\packages\Autodesk.DataExchange.5.2.1-beta\build\Autodesk.DataExchange.targets" Condition="Exists('..\..\packages\Autodesk.DataExchange.5.2.1-beta\build\Autodesk.DataExchange.targets')" />
 </Project>

--- a/src/ConsoleConnector/ConsoleConnector.csproj
+++ b/src/ConsoleConnector/ConsoleConnector.csproj
@@ -57,44 +57,44 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autodesk.DataExchange, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Authentication, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Authentication.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Authentication, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.Authentication.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.ContractProvider, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.ContractProvider.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.ContractProvider, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.ContractProvider.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Core, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Core.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Core, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Exceptions, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Exceptions.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Exceptions, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.Exceptions.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Extensions.HostingProvider, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Extensions.HostingProvider.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Extensions.HostingProvider, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.Extensions.HostingProvider.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Extensions.Logging.File, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Extensions.Logging.File.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Extensions.Logging.File, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.Extensions.Logging.File.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Extensions.Storage.File, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Extensions.Storage.File.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Extensions.Storage.File, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.Extensions.Storage.File.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Metrics, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Metrics.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Metrics, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.Metrics.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.OpenAPI, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.OpenAPI.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.OpenAPI, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.OpenAPI.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Resiliency, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Resiliency.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Resiliency, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.Resiliency.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Schemas, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Schemas.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Schemas, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.Schemas.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.SourceProvider, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.SourceProvider.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.SourceProvider, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.SourceProvider.dll</HintPath>
     </Reference>
     <Reference Include="Autodesk.Extensions.Http.ForgeRetry, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Autodesk.Extensions.Http.ForgeRetry.8.0.0\lib\netstandard2.0\Autodesk.Extensions.Http.ForgeRetry.dll</HintPath>
@@ -102,17 +102,11 @@
     <Reference Include="Autodesk.Forge, Version=1.9.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Autodesk.Forge.1.9.8\lib\net48\Autodesk.Forge.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.GeometryPrimitives, Version=0.7.6.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\geometry-primitives-sdk-win-release-x64.0.7.6\lib\net48\Autodesk.GeometryPrimitives.dll</HintPath>
-    </Reference>
-    <Reference Include="Autodesk.GeometryPrimitives.Data, Version=0.7.10.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.1\lib\net48\Autodesk.GeometryPrimitives.Data.dll</HintPath>
-    </Reference>
-    <Reference Include="Autodesk.GeometryUtilities.BRepAPI, Version=0.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.1\lib\net48\Autodesk.GeometryUtilities.BRepAPI.dll</HintPath>
+    <Reference Include="Autodesk.GeometryPrimitives.Data, Version=0.7.11.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.2\lib\net48\Autodesk.GeometryPrimitives.Data.dll</HintPath>
     </Reference>
     <Reference Include="Autodesk.GeometryUtilities.MeshAPI, Version=0.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.1\lib\net48\Autodesk.GeometryUtilities.MeshAPI.dll</HintPath>
+      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.2\lib\net48\Autodesk.GeometryUtilities.MeshAPI.dll</HintPath>
     </Reference>
     <Reference Include="CBOR, Version=4.5.2.0, Culture=neutral, PublicKeyToken=9cd62db60ea5554c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\PeterO.Cbor.4.5.2\lib\net40\CBOR.dll</HintPath>
@@ -523,13 +517,9 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets'))" />
-    <Error Condition="!Exists('..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets'))" />
-    <Error Condition="!Exists('..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Autodesk.DataExchange.5.2.1-beta\build\Autodesk.DataExchange.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Autodesk.DataExchange.5.2.1-beta\build\Autodesk.DataExchange.targets'))" />
   </Target>
   <Import Project="..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets" Condition="Exists('..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets')" />
   <Import Project="..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets" Condition="Exists('..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets')" />
   <Import Project="..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets" Condition="Exists('..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets')" />
-  <Import Project="..\..\packages\Autodesk.DataExchange.5.2.1-beta\build\Autodesk.DataExchange.targets" Condition="Exists('..\..\packages\Autodesk.DataExchange.5.2.1-beta\build\Autodesk.DataExchange.targets')" />
+  <Import Project="..\..\packages\Autodesk.DataExchange.5.2.2-beta\build\Autodesk.DataExchange.targets" Condition="Exists('..\..\packages\Autodesk.DataExchange.5.2.2-beta\build\Autodesk.DataExchange.targets')" />
 </Project>

--- a/src/ConsoleConnector/Helper/GeometryHelper.cs
+++ b/src/ConsoleConnector/Helper/GeometryHelper.cs
@@ -1,11 +1,11 @@
 ﻿using Autodesk.DataExchange.DataModels;
-using Autodesk.GeometryPrimitives.Design;
-using Autodesk.GeometryPrimitives.Geometry;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-using PrimitiveGeometry = Autodesk.GeometryPrimitives;
+using PrimitiveData = Autodesk.GeometryPrimitives.Data;
+using Autodesk.GeometryPrimitives.Data.DX;
+using Autodesk.GeometryUtilities.MeshAPI;
 
 namespace Autodesk.DataExchange.ConsoleApp.Helper
 {
@@ -58,6 +58,203 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
             return CreateGeometry(elementDataModel, details);
         }
 
+        public Element CreateMeshThroughMeshApi(ElementDataModel elementDataModel)
+        {
+            var complexMeshObject = GetMeshObject();
+            var complexMeshGeom = ElementDataModel.CreateMeshGeometry(new GeometryProperties(complexMeshObject, "Complex Mesh With Color"));
+            var complexMeshElement = elementDataModel.AddElement(new ElementProperties("ComplexMesh", "ComplexSampleMesh", "Mesh", "Mesh", "Complex In memory mesh"));
+            elementDataModel.SetElementGeometryByElement(complexMeshElement, new List<ElementGeometry> { complexMeshGeom });
+            return complexMeshElement;
+        }
+
+        private Autodesk.GeometryUtilities.MeshAPI.Mesh GetMeshObject()
+        {
+            return new Autodesk.GeometryUtilities.MeshAPI.Mesh()
+            {
+                MeshColor = new Color(0.5f, 0.5f, 0.5f, 1.0f),  // mesh body color
+                Vertices = new List<Vertex>
+                {
+                    new Vertex(0.0, 0.0, 0.0),
+                    new Vertex(1.0, 0.0, 0.0),
+                    new Vertex(0.0, 1.0, 0.0),
+                    new Vertex(1.0, 1.0, 0.0),
+                    new Vertex(0.0, 0.0, 1.0),
+                    new Vertex(1.0, 0.0, 1.0),
+                    new Vertex(0.0, 1.0, 1.0),
+                    new Vertex(1.0, 1.0, 1.0),
+                    new Vertex(0.5, 0.5, 1.5),
+                },
+                Faces = new List<Face>
+                {
+                    new Face()
+                    {
+                        Corners = new List<int> { 0, 1, 2 },
+                        Normals = new List<Normal>
+                        {
+                            new Normal(0, 0, 1),
+                            new Normal(0, 0, 1),
+                            new Normal(0, 0, 1),
+                        },
+                        FaceColor = new Color(0.2f, 0.2f, 0.9f, 1.0f),  // face color
+                    },
+                    new Face()
+                    {
+                        Corners = new List<int> { 2, 1, 3 },
+                        Normals = new List<Normal>
+                        {
+                            new Normal(0, 0, 1),
+                            new Normal(0, 0, 1),
+                            new Normal(0, 0, 1),
+                        },
+                        FaceColor = new Color(0.2f, 0.9f, 0.2f, 1.0f),  // face color
+                    },
+                    new Face()
+                    {
+                        Corners = new List<int> { 0, 1, 4 },
+                        Normals = new List<Normal>
+                        {
+                            new Normal(0, 1, 0),
+                            new Normal(0, 1, 0),
+                            new Normal(0, 1, 0),
+                        },
+                        FaceColor = new Color(0.9f, 0.2f, 0.2f, 1.0f),  // face color
+                    },
+                    new Face()
+                    {
+                        Corners = new List<int> { 1, 5, 4 },
+                        Normals = new List<Normal>
+                        {
+                            new Normal(0, 1, 0),
+                            new Normal(0, 1, 0),
+                            new Normal(0, 1, 0),
+                        },
+                        FaceColor = new Color(0.9f, 0.2f, 0.2f, 1.0f),  // face color
+                    },
+                    new Face()
+                    {
+                        Corners = new List<int> { 0, 2, 4 },
+                        Normals = new List<Normal>
+                        {
+                            new Normal(1, 0, 0),
+                            new Normal(1, 0, 0),
+                            new Normal(1, 0, 0),
+                        },
+                        FaceColor = new Color(0.2f, 0.9f, 0.9f, 1.0f),  // face color
+                    },
+                    new Face()
+                    {
+                        Corners = new List<int> { 2, 6, 4 },
+                        Normals = new List<Normal>
+                        {
+                            new Normal(1, 0, 0),
+                            new Normal(1, 0, 0),
+                            new Normal(1, 0, 0),
+                        },
+                        FaceColor = new Color(0.2f, 0.9f, 0.9f, 1.0f),  // face color
+                    },
+                    new Face()
+                    {
+                        Corners = new List<int> { 1, 3, 5 },
+                        Normals = new List<Normal>
+                        {
+                            new Normal(0, -1, 0),
+                            new Normal(0, -1, 0),
+                            new Normal(0, -1, 0),
+                        },
+                        FaceColor = new Color(0.9f, 0.9f, 0.2f, 1.0f),  // face color
+                    },
+                    new Face()
+                    {
+                        Corners = new List<int> { 3, 7, 5 },
+                        Normals = new List<Normal>
+                        {
+                            new Normal(0, -1, 0),
+                            new Normal(0, -1, 0),
+                            new Normal(0, -1, 0),
+                        },
+                        FaceColor = new Color(0.9f, 0.9f, 0.2f, 1.0f),  // face color
+                    },
+                    new Face()
+                    {
+                        Corners = new List<int> { 2, 3, 6 },
+                        Normals = new List<Normal>
+                        {
+                            new Normal(-1, 0, 0),
+                            new Normal(-1, 0, 0),
+                            new Normal(-1, 0, 0),
+                        },
+                        FaceColor = new Color(0.9f, 0.2f, 0.9f, 1.0f),  // face color
+                    },
+                    new Face()
+                    {
+                        Corners = new List<int> { 3, 7, 6 },
+                        Normals = new List<Normal>
+                        {
+                            new Normal(-1, 0, 0),
+                            new Normal(-1, 0, 0),
+                            new Normal(-1, 0, 0),
+                        },
+                        FaceColor = new Color(0.9f, 0.2f, 0.9f, 1.0f),  // face color
+                    },
+                    new Face()
+                    {
+                        Corners = new List<int> { 4, 5, 6 },
+                        Normals = new List<Normal>
+                        {
+                            new Normal(0, 0, -1),
+                            new Normal(0, 0, -1),
+                            new Normal(0, 0, -1),
+                        },
+                        FaceColor = new Color(0.2f, 0.2f, 0.2f, 1.0f),  // face color
+                    },
+                    new Face()
+                    {
+                        Corners = new List<int> { 5, 7, 6 },
+                        Normals = new List<Normal>
+                        {
+                            new Normal(0, 0, -1),
+                            new Normal(0, 0, -1),
+                            new Normal(0, 0, -1),
+                        },
+                        FaceColor = new Color(0.2f, 0.2f, 0.2f, 1.0f),  // face color
+                    },
+                    new Face()
+                    {
+                        Corners = new List<int> { 4, 6, 8 },
+                        Normals = new List<Normal>
+                        {
+                            new Normal(0, 0, 1),
+                            new Normal(0, 0, 1),
+                            new Normal(0, 0, 1),
+                        },
+                        FaceColor = new Color(0.5f, 0.5f, 0.5f, 1.0f),  // face color
+                    },
+                    new Face()
+                    {
+                        Corners = new List<int> { 5, 7, 8 },
+                        Normals = new List<Normal>
+                        {
+                            new Normal(0, 0, 1),
+                            new Normal(0, 0, 1),
+                            new Normal(0, 0, 1),
+                        },
+                        FaceColor = new Color(0.5f, 0.5f, 0.5f, 1.0f),  // face color
+                    },
+                    new Face()
+                    {
+                        Corners = new List<int> { 6, 7, 8 },
+                        Normals = new List<Normal>
+                        {
+                            new Normal(0, 0, 1),
+                            new Normal(0, 0, 1),
+                            new Normal(0, 0, 1),
+                        },
+                        FaceColor = new Color(0.5f, 0.5f, 0.5f, 1.0f),  // face color
+                    },
+                },
+            };
+        }
+
         public Element CreateIfc(ElementDataModel elementDataModel)
         {
             var details = ifcFileDetails[random.Next(ifcFileDetails.Count)];
@@ -68,7 +265,7 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
         {
             var path = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}\\Assets\\" + geometryDetails.Item1;
             var geometry = ElementDataModel.CreateGeometry(new GeometryProperties(path, commonRenderStyle));
-            var element = elementDataModel.AddElement(new ElementProperties(Guid.NewGuid().ToString(),"SampleGeometry", geometryDetails.Item2, geometryDetails.Item3, geometryDetails.Item4));
+            var element = elementDataModel.AddElement(new ElementProperties(Guid.NewGuid().ToString(), "SampleGeometry", geometryDetails.Item2, geometryDetails.Item3, geometryDetails.Item4));
             var elementGeometry = new List<ElementGeometry> { geometry };
             elementDataModel.SetElementGeometryByElement(element, elementGeometry);
             return element;
@@ -80,16 +277,17 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
 
             var newBRepElementGeometry = new List<ElementGeometry>();
 
-            PrimitiveGeometry.Design.CurveSet setOfLines = new PrimitiveGeometry.Design.CurveSet();
+            CurveSet setOfLines = new CurveSet();
 
-            PrimitiveGeometry.Geometry.Line lineone = new PrimitiveGeometry.Geometry.Line(new 
-                PrimitiveGeometry.Math.Point3d { X = random.Next(999), Y = random.Next(999), Z = random.Next(999) }, 
-                new PrimitiveGeometry.Math.Vector3d { X = random.Next(999), Y = random.Next(999), Z = random.Next(999) });
-            lineone.Range = new PrimitiveGeometry.Geometry.ParamRange()
+            PrimitiveData.Line lineone = new PrimitiveData.Line(new
+                PrimitiveData.Point3d
+            { X = random.Next(999), Y = random.Next(999), Z = random.Next(999) },
+                new PrimitiveData.Vector3d { X = random.Next(999), Y = random.Next(999), Z = random.Next(999) });
+            lineone.Range = new PrimitiveData.ParamRange()
             {
                 High = 3.5,
                 Low = 0,
-                Type = PrimitiveGeometry.Geometry.ParamRange.RangeType.Finite
+                Type = PrimitiveData.ParamRange.RangeType.Finite
             };
 
             setOfLines.Add(lineone);
@@ -102,9 +300,9 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
         public Element AddPoint(ElementDataModel elementDataModel)
         {
             var geomContainer = new GeometryContainer();
-            var newPointElement = elementDataModel.AddElement(new ElementProperties(Guid.NewGuid().ToString(),"SamplePoint", "Point", "Point", "Point"));
+            var newPointElement = elementDataModel.AddElement(new ElementProperties(Guid.NewGuid().ToString(), "SamplePoint", "Point", "Point", "Point"));
             var newPointElementGeometry = new List<ElementGeometry>();
-            PrimitiveGeometry.Design.DesignPoint point = new PrimitiveGeometry.Design.DesignPoint(random.Next(999), random.Next(999), random.Next(999));
+            DesignPoint point = new DesignPoint(random.Next(999), random.Next(999), random.Next(999));
             newPointElementGeometry.Add(ElementDataModel.CreatePrimitiveGeometry(new GeometryProperties(point, commonRenderStyle)));
             elementDataModel.SetElementGeometryByElement(newPointElement, newPointElementGeometry);
             return newPointElement;
@@ -113,12 +311,12 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
         public Element AddCircle(ElementDataModel elementDataModel)
         {
             var geomContainer = new GeometryContainer();
-            var circleElement = elementDataModel.AddElement(new ElementProperties(Guid.NewGuid().ToString(),"SampleCircle", "Circle", "Circle", "Circle"));
+            var circleElement = elementDataModel.AddElement(new ElementProperties(Guid.NewGuid().ToString(), "SampleCircle", "Circle", "Circle", "Circle"));
             var newPointElementGeometry = new List<ElementGeometry>();
-            var center = new PrimitiveGeometry.Math.Point3d(random.Next(999), random.Next(999), random.Next(999));
-            var normal = new PrimitiveGeometry.Math.Vector3d(0, 0, 1);
-            var radius = new PrimitiveGeometry.Math.Vector3d(random.Next(50), 0, 0);
-            var circle = new PrimitiveGeometry.Geometry.Circle(center, normal, radius);
+            var center = new PrimitiveData.Point3d(random.Next(999), random.Next(999), random.Next(999));
+            var normal = new PrimitiveData.Vector3d(0, 0, 1);
+            var radius = new PrimitiveData.Vector3d(random.Next(50), 0, 0);
+            var circle = new PrimitiveData.Circle(center, normal, radius);
             geomContainer.Curves.Add(circle);
             newPointElementGeometry.Add(ElementDataModel.CreatePrimitiveGeometry(new GeometryProperties(geomContainer, commonRenderStyle)));
             elementDataModel.SetElementGeometryByElement(circleElement, newPointElementGeometry);
@@ -128,41 +326,41 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
         public Element AddPrimitive(ElementDataModel elementDataModel)
         {
             //....Primitive geometry - Circle...
-            var primitive = elementDataModel.AddElement(new ElementProperties(Guid.NewGuid().ToString(),"SamplePrimitive", "Primitive", "Primitive", "Primitive"));
+            var primitive = elementDataModel.AddElement(new ElementProperties(Guid.NewGuid().ToString(), "SamplePrimitive", "Primitive", "Primitive", "Primitive"));
             var circleElementGeometry = new List<ElementGeometry>();
             var geomContainer = new GeometryContainer()
             {
-                Curves = new CurveArray()
+                Curves = new List<PrimitiveData.Curve>()
                         {
-                             new Line()
+                             new PrimitiveData.Line()
                              {
-                                Position = new PrimitiveGeometry.Math.Point3d(0, 0, 0),
-                                Direction = new PrimitiveGeometry.Math.Vector3d(1, 0, 0),
-                                Range = new ParamRange(ParamRange.RangeType.Finite, -1000, 1000)
+                                Position = new PrimitiveData.Point3d(0, 0, 0),
+                                Direction = new PrimitiveData.Vector3d(1, 0, 0),
+                                Range = new PrimitiveData.ParamRange(PrimitiveData.ParamRange.RangeType.Finite, -1000, 1000)
                              },
-                            new Circle()
+                            new PrimitiveData.Circle()
                             {
-                                Center = new PrimitiveGeometry.Math.Point3d(0, 0, 0),
-                                Normal = new PrimitiveGeometry.Math.Vector3d(0, 0, 1),
-                                Radius = new PrimitiveGeometry.Math.Vector3d(500, 0, 0)
+                                Center = new PrimitiveData.Point3d(0, 0, 0),
+                                Normal = new PrimitiveData.Vector3d(0, 0, 1),
+                                Radius = new PrimitiveData.Vector3d(500, 0, 0)
                             },
                             //CCW 90degree
-                            new Circle()
+                            new PrimitiveData.Circle()
                             {
-                                Center = new PrimitiveGeometry.Math.Point3d(700, 0, 0),
-                                Normal = new PrimitiveGeometry.Math.Vector3d(0, 0, 1),
-                                Radius = new PrimitiveGeometry.Math.Vector3d(200, 0, 0),
-                                Range = new ParamRange(ParamRange.RangeType.Finite,0,1.5708)
+                                Center = new PrimitiveData.Point3d(700, 0, 0),
+                                Normal = new PrimitiveData.Vector3d(0, 0, 1),
+                                Radius = new PrimitiveData.Vector3d(200, 0, 0),
+                                Range = new PrimitiveData.ParamRange(PrimitiveData.ParamRange.RangeType.Finite,0,1.5708)
                             },
                             //CW 90degree
-                            new Circle()
+                            new PrimitiveData.Circle()
                             {
-                                Center = new PrimitiveGeometry.Math.Point3d(1000, 0, 0),
-                                Normal = new PrimitiveGeometry.Math.Vector3d(0, 0, 1),
-                                Radius = new PrimitiveGeometry.Math.Vector3d(200, 0, 0),
-                                Range = new ParamRange(ParamRange.RangeType.Finite,-1.5708,0)
+                                Center = new PrimitiveData.Point3d(1000, 0, 0),
+                                Normal = new PrimitiveData.Vector3d(0, 0, 1),
+                                Radius = new PrimitiveData.Vector3d(200, 0, 0),
+                                Range = new PrimitiveData.ParamRange(PrimitiveData.ParamRange.RangeType.Finite,-1.5708,0)
                             },
-                            new Autodesk.GeometryPrimitives.Geometry.BCurve()
+                            new PrimitiveData.BCurve()
                             {
                                 Degree = 3,
                                 Knots = new List<double>() {
@@ -172,52 +370,52 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
                                     61.767382623682536,
                                     86.37111048613733, 86.37111048613733, 86.37111048613733, 86.37111048613733
                                 },
-                                ControlPoints = new List<Autodesk.GeometryPrimitives.Math.Point3d>()
+                                ControlPoints = new List<PrimitiveData.Point3d>()
                                 {
-                                    new Autodesk.GeometryPrimitives.Math.Point3d(-2117.6323100866352, -578.0819231498238, 0),
-                                    new Autodesk.GeometryPrimitives.Math.Point3d(-1412.0457600104123, -249.06151135811626, 0),
-                                    new Autodesk.GeometryPrimitives.Math.Point3d(-1846.6021471151125, 185.49487574658576, 0),
-                                    new Autodesk.GeometryPrimitives.Math.Point3d(-1223.20576487363, 185.49487574658374, 0),
-                                    new Autodesk.GeometryPrimitives.Math.Point3d(-908.8865372007543, 366.96716645499356, 0),
-                                    new Autodesk.GeometryPrimitives.Math.Point3d(-981.7326274133812, -674.7804577820922, 0),
-                                    new Autodesk.GeometryPrimitives.Math.Point3d(-218.14218928271805, -1030.8485267763535, 0)
+                                    new PrimitiveData.Point3d(-2117.6323100866352, -578.0819231498238, 0),
+                                    new PrimitiveData.Point3d(-1412.0457600104123, -249.06151135811626, 0),
+                                    new PrimitiveData.Point3d(-1846.6021471151125, 185.49487574658576, 0),
+                                    new PrimitiveData.Point3d(-1223.20576487363, 185.49487574658374, 0),
+                                    new PrimitiveData.Point3d(-908.8865372007543, 366.96716645499356, 0),
+                                    new PrimitiveData.Point3d(-981.7326274133812, -674.7804577820922, 0),
+                                    new PrimitiveData.Point3d(-218.14218928271805, -1030.8485267763535, 0)
                                 },
                                 Weights = new List<double>() { 1, 1, 1, 1, 1, 1, 1 }
                             },
-                            new Ellipse()
+                            new PrimitiveData.Ellipse()
                             {
-                                Center = new PrimitiveGeometry.Math.Point3d(0, 0, 0),
-                                Normal = new PrimitiveGeometry.Math.Vector3d(0, 0, 1),
-                                MajorRadius = new PrimitiveGeometry.Math.Vector3d(500, 0, 0),
+                                Center = new PrimitiveData.Point3d(0, 0, 0),
+                                Normal = new PrimitiveData.Vector3d(0, 0, 1),
+                                MajorRadius = new PrimitiveData.Vector3d(500, 0, 0),
                                 RadiusRatio = 0.7
                             }
 
                         },
-                Surfaces = new Autodesk.GeometryPrimitives.Design.SurfaceArray()
+                Surfaces = new List<PrimitiveData.Surface>()
                         {
-                             new Autodesk.GeometryPrimitives.Geometry.Plane()
+                             new PrimitiveData.Plane()
                              {
-                                 Origin = new Autodesk.GeometryPrimitives.Math.Point3d(0, -270.888, 7.8900e-3),
-                                 Normal = new Autodesk.GeometryPrimitives.Math.Vector3d(1, 0, 0),
-                                 UAxis = new Autodesk.GeometryPrimitives.Math.Vector3d(0, 1, 0),
-                                 URange = new Autodesk.GeometryPrimitives.Geometry.ParamRange(
-                                     Autodesk.GeometryPrimitives.Geometry.ParamRange.RangeType.Finite,
+                                 Origin = new PrimitiveData.Point3d(0, -270.888, 7.8900e-3),
+                                 Normal = new PrimitiveData.Vector3d(1, 0, 0),
+                                 UAxis = new PrimitiveData.Vector3d(0, 1, 0),
+                                 URange = new PrimitiveData.ParamRange(
+                                     PrimitiveData.ParamRange.RangeType.Finite,
                                      0,
                                      2000
                                  ),
-                                 VRange = new Autodesk.GeometryPrimitives.Geometry.ParamRange(
-                                     Autodesk.GeometryPrimitives.Geometry.ParamRange.RangeType.Finite,
+                                 VRange = new PrimitiveData.ParamRange(
+                                     PrimitiveData.ParamRange.RangeType.Finite,
                                      0,
                                      1000
                                  )
                              },
-                             new Autodesk.GeometryPrimitives.Geometry.Plane()
+                             new PrimitiveData.Plane()
                              {
-                                 Origin = new Autodesk.GeometryPrimitives.Math.Point3d(0, -2000, 0),
-                                 Normal = new Autodesk.GeometryPrimitives.Math.Vector3d(1, 0, 0),
-                                 UAxis = new Autodesk.GeometryPrimitives.Math.Vector3d(0, 1, 0),
-                                 URange = new Autodesk.GeometryPrimitives.Geometry.ParamRange(
-                                     Autodesk.GeometryPrimitives.Geometry.ParamRange.RangeType.Finite,
+                                 Origin = new PrimitiveData.Point3d(0, -2000, 0),
+                                 Normal = new PrimitiveData.Vector3d(1, 0, 0),
+                                 UAxis = new PrimitiveData.Vector3d(0, 1, 0),
+                                 URange = new PrimitiveData.ParamRange(
+                                     PrimitiveData.ParamRange.RangeType.Finite,
                                      0,
                                      700
                                  ),
@@ -232,21 +430,21 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
 
         public Element AddPolyline(ElementDataModel dataModel)
         {
-            var polyLineElement = dataModel.AddElement(new ElementProperties("Polyline","SamplePolyline", "PolylineGenerics", "PolylineGeneric", "PolylineElement"));
+            var polyLineElement = dataModel.AddElement(new ElementProperties("Polyline", "SamplePolyline", "PolylineGenerics", "PolylineGeneric", "PolylineElement"));
             var polyLineElementGeometry = new List<ElementGeometry>();
             var geomContainer = new GeometryContainer()
             {
-                Curves = new CurveArray()
+                Curves = new List<PrimitiveData.Curve>()
                 {
-                    new Polyline()
+                    new PrimitiveData.Polyline()
                     {
-                        Range = new ParamRange(ParamRange.RangeType.Finite, 0.0, 2.0),
+                        Range = new PrimitiveData.ParamRange(PrimitiveData.ParamRange.RangeType.Finite, 0.0, 2.0),
                         Closed = false,
-                        Points = new List<PrimitiveGeometry.Math.Point3d>()
+                        Points = new List<PrimitiveData.Point3d>()
                         {
-                            new PrimitiveGeometry.Math.Point3d(12.5, 4, 0),
-                            new PrimitiveGeometry.Math.Point3d(4.5, 4, 0),
-                            new PrimitiveGeometry.Math.Point3d(11.25, 0, 0)
+                            new PrimitiveData.Point3d(12.5, 4, 0),
+                            new PrimitiveData.Point3d(4.5, 4, 0),
+                            new PrimitiveData.Point3d(11.25, 0, 0)
                         }
                     }
                 }

--- a/src/ConsoleConnector/packages.config
+++ b/src/ConsoleConnector/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autodesk.DataExchange" version="5.1.1-beta" targetFramework="net48" />
+  <package id="Autodesk.DataExchange" version="5.2.1-beta" targetFramework="net48" />
+  <package id="Autodesk.DataExchange.GeometryDefinitions" version="0.1.1" targetFramework="net48" />
   <package id="Autodesk.Extensions.Http.ForgeRetry" version="8.0.0" targetFramework="net48" />
   <package id="Autodesk.Forge" version="1.9.8" targetFramework="net48" />
   <package id="ForgeParameters-csharp_win_release_intel64_v140" version="3.0.6" targetFramework="net48" />

--- a/src/ConsoleConnector/packages.config
+++ b/src/ConsoleConnector/packages.config
@@ -1,12 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autodesk.DataExchange" version="5.2.1-beta" targetFramework="net48" />
-  <package id="Autodesk.DataExchange.GeometryDefinitions" version="0.1.1" targetFramework="net48" />
+  <package id="Autodesk.DataExchange" version="5.2.2-beta" targetFramework="net48" />
+  <package id="Autodesk.DataExchange.GeometryDefinitions" version="0.1.2" targetFramework="net48" />
   <package id="Autodesk.Extensions.Http.ForgeRetry" version="8.0.0" targetFramework="net48" />
   <package id="Autodesk.Forge" version="1.9.8" targetFramework="net48" />
   <package id="ForgeParameters-csharp_win_release_intel64_v140" version="3.0.6" targetFramework="net48" />
   <package id="ForgeUnits-csharp_win_release_intel64_v140" version="5.1.4" targetFramework="net48" />
-  <package id="geometry-primitives-sdk-win-release-x64" version="0.7.6" targetFramework="net48" />
   <package id="Google.Protobuf" version="3.19.4" targetFramework="net48" />
   <package id="IdentityModel" version="5.0.1" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />

--- a/test/ConsoleConnector_Test/ConsoleConnector_Test.csproj
+++ b/test/ConsoleConnector_Test/ConsoleConnector_Test.csproj
@@ -57,44 +57,44 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autodesk.DataExchange, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Authentication, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.Authentication.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Authentication, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Authentication.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.ContractProvider, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.ContractProvider.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.ContractProvider, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.ContractProvider.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Core, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.Core.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Core, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Exceptions, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.Exceptions.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Exceptions, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Exceptions.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Extensions.HostingProvider, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.Extensions.HostingProvider.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Extensions.HostingProvider, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Extensions.HostingProvider.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Extensions.Logging.File, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.Extensions.Logging.File.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Extensions.Logging.File, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Extensions.Logging.File.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Extensions.Storage.File, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.Extensions.Storage.File.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Extensions.Storage.File, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Extensions.Storage.File.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Metrics, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.Metrics.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Metrics, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Metrics.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.OpenAPI, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.OpenAPI.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.OpenAPI, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.OpenAPI.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Resiliency, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.Resiliency.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Resiliency, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Resiliency.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Schemas, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.Schemas.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Schemas, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Schemas.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.SourceProvider, Version=5.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.1.1-beta\lib\net48\Autodesk.DataExchange.SourceProvider.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.SourceProvider, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.SourceProvider.dll</HintPath>
     </Reference>
     <Reference Include="Autodesk.Extensions.Http.ForgeRetry, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Autodesk.Extensions.Http.ForgeRetry.8.0.0\lib\netstandard2.0\Autodesk.Extensions.Http.ForgeRetry.dll</HintPath>
@@ -104,6 +104,15 @@
     </Reference>
     <Reference Include="Autodesk.GeometryPrimitives, Version=0.7.6.0, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>..\..\packages\geometry-primitives-sdk-win-release-x64.0.7.6\lib\net48\Autodesk.GeometryPrimitives.dll</HintPath>
+    </Reference>
+    <Reference Include="Autodesk.GeometryPrimitives.Data, Version=0.7.10.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.1\lib\net48\Autodesk.GeometryPrimitives.Data.dll</HintPath>
+    </Reference>
+    <Reference Include="Autodesk.GeometryUtilities.BRepAPI, Version=0.0.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.1\lib\net48\Autodesk.GeometryUtilities.BRepAPI.dll</HintPath>
+    </Reference>
+    <Reference Include="Autodesk.GeometryUtilities.MeshAPI, Version=0.0.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.1\lib\net48\Autodesk.GeometryUtilities.MeshAPI.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Core.5.1.1\lib\net462\Castle.Core.dll</HintPath>
@@ -450,11 +459,11 @@
     <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets'))" />
     <Error Condition="!Exists('..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Autodesk.DataExchange.5.1.1-beta\build\Autodesk.DataExchange.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Autodesk.DataExchange.5.1.1-beta\build\Autodesk.DataExchange.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Autodesk.DataExchange.5.2.1-beta\build\Autodesk.DataExchange.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Autodesk.DataExchange.5.2.1-beta\build\Autodesk.DataExchange.targets'))" />
   </Target>
   <Import Project="..\..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets')" />
   <Import Project="..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets" Condition="Exists('..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets')" />
   <Import Project="..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets" Condition="Exists('..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets')" />
   <Import Project="..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets" Condition="Exists('..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets')" />
-  <Import Project="..\..\packages\Autodesk.DataExchange.5.1.1-beta\build\Autodesk.DataExchange.targets" Condition="Exists('..\..\packages\Autodesk.DataExchange.5.1.1-beta\build\Autodesk.DataExchange.targets')" />
+  <Import Project="..\..\packages\Autodesk.DataExchange.5.2.1-beta\build\Autodesk.DataExchange.targets" Condition="Exists('..\..\packages\Autodesk.DataExchange.5.2.1-beta\build\Autodesk.DataExchange.targets')" />
 </Project>

--- a/test/ConsoleConnector_Test/ConsoleConnector_Test.csproj
+++ b/test/ConsoleConnector_Test/ConsoleConnector_Test.csproj
@@ -57,44 +57,44 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autodesk.DataExchange, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Authentication, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Authentication.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Authentication, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.Authentication.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.ContractProvider, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.ContractProvider.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.ContractProvider, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.ContractProvider.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Core, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Core.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Core, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Exceptions, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Exceptions.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Exceptions, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.Exceptions.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Extensions.HostingProvider, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Extensions.HostingProvider.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Extensions.HostingProvider, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.Extensions.HostingProvider.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Extensions.Logging.File, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Extensions.Logging.File.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Extensions.Logging.File, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.Extensions.Logging.File.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Extensions.Storage.File, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Extensions.Storage.File.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Extensions.Storage.File, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.Extensions.Storage.File.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Metrics, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Metrics.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Metrics, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.Metrics.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.OpenAPI, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.OpenAPI.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.OpenAPI, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.OpenAPI.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Resiliency, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Resiliency.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Resiliency, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.Resiliency.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.Schemas, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.Schemas.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.Schemas, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.Schemas.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange.SourceProvider, Version=5.2.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.1-beta\lib\net48\Autodesk.DataExchange.SourceProvider.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange.SourceProvider, Version=5.2.2.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.5.2.2-beta\lib\net48\Autodesk.DataExchange.SourceProvider.dll</HintPath>
     </Reference>
     <Reference Include="Autodesk.Extensions.Http.ForgeRetry, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Autodesk.Extensions.Http.ForgeRetry.8.0.0\lib\netstandard2.0\Autodesk.Extensions.Http.ForgeRetry.dll</HintPath>
@@ -102,17 +102,11 @@
     <Reference Include="Autodesk.Forge, Version=1.9.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Autodesk.Forge.1.9.8\lib\net48\Autodesk.Forge.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.GeometryPrimitives, Version=0.7.6.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\geometry-primitives-sdk-win-release-x64.0.7.6\lib\net48\Autodesk.GeometryPrimitives.dll</HintPath>
-    </Reference>
-    <Reference Include="Autodesk.GeometryPrimitives.Data, Version=0.7.10.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.1\lib\net48\Autodesk.GeometryPrimitives.Data.dll</HintPath>
-    </Reference>
-    <Reference Include="Autodesk.GeometryUtilities.BRepAPI, Version=0.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.1\lib\net48\Autodesk.GeometryUtilities.BRepAPI.dll</HintPath>
+    <Reference Include="Autodesk.GeometryPrimitives.Data, Version=0.7.11.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.2\lib\net48\Autodesk.GeometryPrimitives.Data.dll</HintPath>
     </Reference>
     <Reference Include="Autodesk.GeometryUtilities.MeshAPI, Version=0.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.1\lib\net48\Autodesk.GeometryUtilities.MeshAPI.dll</HintPath>
+      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.2\lib\net48\Autodesk.GeometryUtilities.MeshAPI.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Core.5.1.1\lib\net462\Castle.Core.dll</HintPath>
@@ -459,11 +453,11 @@
     <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets'))" />
     <Error Condition="!Exists('..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Autodesk.DataExchange.5.2.1-beta\build\Autodesk.DataExchange.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Autodesk.DataExchange.5.2.1-beta\build\Autodesk.DataExchange.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Autodesk.DataExchange.5.2.2-beta\build\Autodesk.DataExchange.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Autodesk.DataExchange.5.2.2-beta\build\Autodesk.DataExchange.targets'))" />
   </Target>
   <Import Project="..\..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets')" />
   <Import Project="..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets" Condition="Exists('..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets')" />
   <Import Project="..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets" Condition="Exists('..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets')" />
   <Import Project="..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets" Condition="Exists('..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets')" />
-  <Import Project="..\..\packages\Autodesk.DataExchange.5.2.1-beta\build\Autodesk.DataExchange.targets" Condition="Exists('..\..\packages\Autodesk.DataExchange.5.2.1-beta\build\Autodesk.DataExchange.targets')" />
+  <Import Project="..\..\packages\Autodesk.DataExchange.5.2.2-beta\build\Autodesk.DataExchange.targets" Condition="Exists('..\..\packages\Autodesk.DataExchange.5.2.2-beta\build\Autodesk.DataExchange.targets')" />
 </Project>

--- a/test/ConsoleConnector_Test/GeometryHelper_Test.cs
+++ b/test/ConsoleConnector_Test/GeometryHelper_Test.cs
@@ -34,7 +34,7 @@ namespace ConsoleConnector_Test
             var exchangeData = ElementDataModel.Create(_client.Object);
             var element = GeometryHelper.CreateBrep(exchangeData);
             Assert.IsNotNull(element);
-            Assert.AreEqual(exchangeData.Elements.Count(),1);
+            Assert.AreEqual(exchangeData.Elements.Count(), 1);
         }
 
         [TestMethod]
@@ -52,8 +52,10 @@ namespace ConsoleConnector_Test
         {
             var exchangeData = ElementDataModel.Create(_client.Object);
             var element = GeometryHelper.CreateMesh(exchangeData);
+            var element2 = GeometryHelper.CreateMeshThroughMeshApi(exchangeData);
             Assert.IsNotNull(element);
-            Assert.AreEqual(exchangeData.Elements.Count(), 1);
+            Assert.IsNotNull(element2);
+            Assert.AreEqual(exchangeData.Elements.Count(), 2);
         }
 
         [TestMethod]
@@ -102,3 +104,9 @@ namespace ConsoleConnector_Test
         }
     }
 }
+
+
+
+
+
+

--- a/test/ConsoleConnector_Test/packages.config
+++ b/test/ConsoleConnector_Test/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autodesk.DataExchange" version="5.1.1-beta" targetFramework="net48" />
+  <package id="Autodesk.DataExchange" version="5.2.1-beta" targetFramework="net48" />
+  <package id="Autodesk.DataExchange.GeometryDefinitions" version="0.1.1" targetFramework="net48" />
   <package id="Autodesk.Extensions.Http.ForgeRetry" version="8.0.0" targetFramework="net48" />
   <package id="Autodesk.Forge" version="1.9.8" targetFramework="net48" />
   <package id="Castle.Core" version="5.1.1" targetFramework="net48" />

--- a/test/ConsoleConnector_Test/packages.config
+++ b/test/ConsoleConnector_Test/packages.config
@@ -1,13 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autodesk.DataExchange" version="5.2.1-beta" targetFramework="net48" />
-  <package id="Autodesk.DataExchange.GeometryDefinitions" version="0.1.1" targetFramework="net48" />
+  <package id="Autodesk.DataExchange" version="5.2.2-beta" targetFramework="net48" />
+  <package id="Autodesk.DataExchange.GeometryDefinitions" version="0.1.2" targetFramework="net48" />
   <package id="Autodesk.Extensions.Http.ForgeRetry" version="8.0.0" targetFramework="net48" />
   <package id="Autodesk.Forge" version="1.9.8" targetFramework="net48" />
   <package id="Castle.Core" version="5.1.1" targetFramework="net48" />
   <package id="ForgeParameters-csharp_win_release_intel64_v140" version="3.0.6" targetFramework="net48" />
   <package id="ForgeUnits-csharp_win_release_intel64_v140" version="5.1.4" targetFramework="net48" />
-  <package id="geometry-primitives-sdk-win-release-x64" version="0.7.6" targetFramework="net48" />
   <package id="Google.Protobuf" version="3.19.4" targetFramework="net48" />
   <package id="IdentityModel" version="5.0.1" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />


### PR DESCRIPTION
Update to Autodesk.DataExchange 5.2.2-beta, add new Geometry APIs, and fix formatting issues

- Updated `ConsoleConnector.csproj` and `ConsoleConnector_Test.csproj` to reference Autodesk.DataExchange 5.2.2-beta and add new libraries: `Autodesk.GeometryPrimitives.Data`, `Autodesk.GeometryUtilities.BRepAPI`, and `Autodesk.GeometryUtilities.MeshAPI`.
- Modified `packages.config` to upgrade Autodesk.DataExchange to 5.2.2-beta and add `Autodesk.DataExchange.GeometryDefinitions` 0.1.2.
- Enhanced `GeometryHelper` with new methods `CreateMeshThroughMeshApi` and `GetMeshObject`, and updated existing methods to use new `PrimitiveData` classes.
- Updated `CreateMeshCommand.cs` to use the new mesh creation API and print mesh details.
- Fixed formatting issues in `HelpCommand.cs`, `SetFolderCommand.cs`, and `GeometryHelper_Test.cs`.
