### PR TITLE
Improve SetFolder error handling, validation, and diagnostics

### DIFF
--- a/src/ConsoleConnector/Commands/SetFolderCommand.cs
+++ b/src/ConsoleConnector/Commands/SetFolderCommand.cs
@@ -36,54 +36,94 @@ namespace Autodesk.DataExchange.ConsoleApp.Commands
             return new SetFolderCommand(this);
         }
 
-        public override Task<bool> Execute()
+        public override async Task<bool> Execute()
         {
             var check = this.GetOption<HubId>().Value;
-            if (check!=null && check.Contains("http"))
+            if (check != null && check.Contains("http"))
             {
-                return Execute(check);
+                return await ExecuteWithUrl(check);
             }
             if (this.ValidateOptions() == false)
             {
-                Console.WriteLine("Invalid inputs!!!");
-                return Task.FromResult(false);
+                var missing = new List<string>();
+                if (!this.GetOption<HubId>().IsValid()) missing.Add("HubId");
+                if (!this.GetOption<Region>().IsValid()) missing.Add("Region");
+                if (!this.GetOption<ProjectUrn>().IsValid()) missing.Add("ProjectUrn");
+                if (!this.GetOption<FolderUrn>().IsValid()) missing.Add("FolderUrn");
+                Console.WriteLine($"[ERROR] Invalid inputs. Missing required fields: {string.Join(", ", missing)}");
+                return false;
             }
             var hubId = this.GetOption<HubId>();
             var region = this.GetOption<Region>();
             var projectUrn = this.GetOption<ProjectUrn>();
             var folderUrn = this.GetOption<FolderUrn>();
-            ConsoleAppHelper.SetFolder(region.Value,hubId.Value,projectUrn.Value,folderUrn.Value);
+
+            var validation = await ConsoleAppHelper.ValidateHubAccessAsync(hubId.Value, projectUrn.Value);
+            if (!validation.IsValid)
+            {
+                Console.WriteLine(validation.ErrorMessage);
+                return false;
+            }
+
+            ConsoleAppHelper.GetRegion(hubId.Value, out string resolvedRegion);
+            if (!string.IsNullOrEmpty(resolvedRegion) &&
+                !string.Equals(region.Value, resolvedRegion, StringComparison.OrdinalIgnoreCase))
+            {
+                Console.WriteLine($"[WARNING] Provided region '{region.Value}' differs from the resolved region '{resolvedRegion}'. Using resolved region.");
+                ConsoleAppHelper.SetFolder(resolvedRegion, hubId.Value, projectUrn.Value, folderUrn.Value);
+            }
+            else
+            {
+                ConsoleAppHelper.SetFolder(region.Value, hubId.Value, projectUrn.Value, folderUrn.Value);
+            }
             Console.WriteLine("Default folder set!!!");
-            return Task.FromResult(true);
+            return true;
         }
 
-        private Task<bool> Execute(string folderUrl)
+        private Task<bool> ExecuteWithUrl(string folderUrl)
         {
-            var projectUrn = "b." + folderUrl.ToString().Split('/')[6].Split('?')[0];
-            var folderUrn = folderUrl.ToString().Split('/')[6].Split('?')[1].Split('&')[0].Split('=')[1].Replace("%3A", ":");
+            string projectUrn;
+            string folderUrn;
+            try
+            {
+                projectUrn = "b." + folderUrl.Split('/')[6].Split('?')[0];
+                folderUrn = folderUrl.Split('/')[6].Split('?')[1].Split('&')[0].Split('=')[1].Replace("%3A", ":");
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("[ERROR] The provided URL format is not recognized. Expected a Forma/ACC folder URL.");
+                return Task.FromResult(false);
+            }
+
+            if (string.IsNullOrEmpty(projectUrn) || projectUrn == "b.")
+            {
+                Console.WriteLine("[ERROR] Could not extract ProjectUrn from the URL. Please verify the URL format.");
+                return Task.FromResult(false);
+            }
+
+            if (string.IsNullOrEmpty(folderUrn))
+            {
+                Console.WriteLine("[ERROR] Could not extract FolderUrn from the URL. Please verify the URL contains a valid folderUrn query parameter.");
+                return Task.FromResult(false);
+            }
 
             ConsoleAppHelper.GetHubId(projectUrn, out string hubId);
             if (string.IsNullOrEmpty(hubId))
             {
-                Console.WriteLine("Invalid FolderUrl!!!");
+                Console.WriteLine(
+                    $"[ERROR] Unable to resolve HubId from the folder URL. " +
+                    "This usually means your app's ClientId has not been added to the Forma/ACC hub " +
+                    $"as a custom integration, or the project in the URL does not exist. (ProjectUrn: '{projectUrn}')");
                 return Task.FromResult(false);
             }
+
             ConsoleAppHelper.GetRegion(hubId, out string region);
-            if (string.IsNullOrEmpty(region)) 
+            if (string.IsNullOrEmpty(region))
             {
-                Console.WriteLine("Invalid FolderUrl!!!");
+                Console.WriteLine($"[ERROR] Unable to resolve region for the hub. The HubId '{hubId}' may be invalid or inaccessible.");
                 return Task.FromResult(false);
             }
-            if (string.IsNullOrEmpty(folderUrn))
-            {
-                Console.WriteLine("Invalid FolderUrl!!!");
-                return Task.FromResult(false);
-            }
-            if (string.IsNullOrEmpty(projectUrn))
-            {
-                Console.WriteLine("Invalid FolderUrl!!!");
-                return Task.FromResult(false);
-            }
+
             ConsoleAppHelper.SetFolder(region, hubId, projectUrn, folderUrn);
             Console.WriteLine("Default folder set!!!");
             return Task.FromResult(true);

--- a/src/ConsoleConnector/Helper/ConsoleAppHelper.cs
+++ b/src/ConsoleConnector/Helper/ConsoleAppHelper.cs
@@ -92,12 +92,88 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
 
         public void GetHubId(string projectUrn, out string hubId)
         {
-            hubId = GetHubIdAsync(projectUrn).Result.Value;
+            hubId = null;
+            try
+            {
+                var response = GetHubIdAsync(projectUrn).Result;
+                if (response == null)
+                {
+                    Console.WriteLine($"[ERROR] GetHubId returned no response for ProjectUrn '{projectUrn}'. " +
+                        "Verify your app has Data Management API permissions and the ClientId is registered as a custom integration in Forma/ACC.");
+                    return;
+                }
+                if (!response.IsSuccess || string.IsNullOrEmpty(response.Value))
+                {
+                    Console.WriteLine($"[ERROR] Failed to resolve HubId for ProjectUrn '{projectUrn}'. " +
+                        "Verify the ProjectUrn is correct and your app's ClientId has been added to the Forma/ACC hub as a custom integration.");
+                    return;
+                }
+                hubId = response.Value;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[ERROR] Exception resolving HubId for ProjectUrn '{projectUrn}': {ex.Message}");
+            }
         }
 
         public void GetRegion(string hubId, out string region)
         {
-            region = GetRegionAsync(hubId).Result;
+            region = null;
+            try
+            {
+                region = GetRegionAsync(hubId).Result;
+                if (string.IsNullOrEmpty(region))
+                {
+                    Console.WriteLine($"[ERROR] Failed to resolve region for HubId '{hubId}'. " +
+                        "Verify the HubId is correct and accessible.");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[ERROR] Exception resolving region for HubId '{hubId}': {ex.Message}");
+                region = null;
+            }
+        }
+
+        public async Task<(bool IsValid, string ErrorMessage)> ValidateHubAccessAsync(string hubId, string projectUrn)
+        {
+            try
+            {
+                var hubIdResponse = await Client.GetHubIdAsync(projectUrn);
+                if (hubIdResponse == null || string.IsNullOrEmpty(hubIdResponse.Value))
+                {
+                    return (false,
+                        $"[ERROR] Unable to resolve HubId for ProjectUrn '{projectUrn}'. " +
+                        "This usually means your app's ClientId has not been added to the Forma/ACC hub " +
+                        "as a custom integration (Step 1c in setup), or the ProjectUrn does not exist.");
+                }
+
+                var resolvedHubId = hubIdResponse.Value;
+                if (!string.IsNullOrEmpty(hubId) && !string.Equals(hubId, resolvedHubId, StringComparison.OrdinalIgnoreCase))
+                {
+                    return (false,
+                        $"[ERROR] Provided HubId '{hubId}' does not match the HubId resolved from ProjectUrn ('{resolvedHubId}'). " +
+                        "Please verify your HubId is correct.");
+                }
+
+                var resolvedRegion = await Client.SDKOptions.HostingProvider.GetRegionAsync(
+                    string.IsNullOrEmpty(hubId) ? resolvedHubId : hubId);
+                if (string.IsNullOrEmpty(resolvedRegion))
+                {
+                    return (false,
+                        $"[ERROR] Unable to resolve region for HubId '{hubId}'. " +
+                        "Verify the HubId is correct and your app has the required permissions.");
+                }
+
+                return (true, null);
+            }
+            catch (Exception ex)
+            {
+                return (false,
+                    $"[ERROR] Folder validation failed: {ex.Message}. " +
+                    "Verify that your app's ClientId has been added to the Forma/ACC hub as a custom integration " +
+                    "and that you have the required permissions (Data Exchange API, Data Management API).");
+            }
         }
 
         public ElementDataModel GetExchangeData(string exchangeTitle)
@@ -265,12 +341,29 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
         public async Task<IResponse<ExchangeDetails>> CreateExchange(string exchangeTitle)
         {
             var name = exchangeTitle;
-            TryGetFolderDetails(out var region, out var hubId, out var projectUrn, out var folderUrn);
+            var folderDetailsMissing = TryGetFolderDetails(out var region, out var hubId, out var projectUrn, out var folderUrn);
+            if (folderDetailsMissing)
+            {
+                var missingFields = new List<string>();
+                if (string.IsNullOrEmpty(region)) missingFields.Add("Region");
+                if (string.IsNullOrEmpty(hubId)) missingFields.Add("HubId");
+                if (string.IsNullOrEmpty(projectUrn)) missingFields.Add("ProjectUrn");
+                if (string.IsNullOrEmpty(folderUrn)) missingFields.Add("FolderUrn");
+                throw new InvalidOperationException(
+                    $"Cannot create exchange: missing folder details ({string.Join(", ", missingFields)}). " +
+                    "Run 'SetFolder' first to configure the target folder.");
+            }
+
             var projectDetails = await Client.SDKOptions.HostingProvider.GetProjectInformationAsync(hubId, projectUrn);
             var projectType = ProjectType.ACC;
             if (projectDetails != null)
             {
                 projectType = projectDetails.ProjectType;
+            }
+            else
+            {
+                Console.WriteLine($"[WARNING] Could not retrieve project information for HubId '{hubId}' and ProjectUrn '{projectUrn}'. " +
+                    "This may indicate incorrect folder details or insufficient permissions.");
             }
 
             var exchangeCreateRequest = new ExchangeCreateRequestACC()

--- a/src/ConsoleConnector/Helper/ConsoleAppHelper.cs
+++ b/src/ConsoleConnector/Helper/ConsoleAppHelper.cs
@@ -145,7 +145,7 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
                     return (false,
                         $"[ERROR] Unable to resolve HubId for ProjectUrn '{projectUrn}'. " +
                         "This usually means your app's ClientId has not been added to the Forma/ACC hub " +
-                        "as a custom integration (Step 1c in setup), or the ProjectUrn does not exist.");
+                        "as a custom integration (via Hub Admin > Custom Integrations), or the ProjectUrn does not exist.");
                 }
 
                 var resolvedHubId = hubIdResponse.Value;

--- a/src/ConsoleConnector/Interfaces/IConsoleAppHelper.cs
+++ b/src/ConsoleConnector/Interfaces/IConsoleAppHelper.cs
@@ -30,6 +30,7 @@ namespace Autodesk.DataExchange.ConsoleApp.Interfaces
         Task<IResponse<ExchangeDetails>> CreateExchange(string exchangeTitle);
         void GetHubId(string projectUrn, out string hubId);
         void GetRegion(string hubId, out string region);
+        Task<(bool IsValid, string ErrorMessage)> ValidateHubAccessAsync(string hubId, string projectUrn);
         Task<bool> SyncExchange(DataExchangeIdentifier dataExchangeIdentifier,ExchangeDetails exchangeDetails, ElementDataModel exchangeData);
 
         IClient GetClient();

--- a/test/ConsoleConnector_Test/Command_Test.cs
+++ b/test/ConsoleConnector_Test/Command_Test.cs
@@ -103,5 +103,166 @@ namespace ConsoleConnector_Test
             task.Wait();
             Assert.AreEqual(task.Result, true);
         }
+
+        [TestMethod]
+        public void SetFolder_IdsPath_ValidationFails_ReturnsFalse()
+        {
+            consoleAppHelper.Setup(n =>
+                n.ValidateHubAccessAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((false, "[ERROR] Unable to resolve HubId for ProjectUrn 'b.wrong-id'. " +
+                    "This usually means your app's ClientId has not been added to the Forma/ACC hub " +
+                    "as a custom integration (Step 1c in setup), or the ProjectUrn does not exist."));
+
+            var setFolder = new SetFolderCommand(consoleAppHelper.Object);
+            setFolder.GetOption<HubId>().SetValue("b.wrong-hub-id");
+            setFolder.GetOption<Region>().SetValue("US");
+            setFolder.GetOption<ProjectUrn>().SetValue("b.wrong-id");
+            setFolder.GetOption<FolderUrn>().SetValue("urn:adsk.wipprod:fs.folder:co.test");
+
+            var task = setFolder.Execute();
+            task.Wait();
+            Assert.AreEqual(false, task.Result);
+
+            consoleAppHelper.Verify(
+                n => n.SetFolder(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never());
+        }
+
+        [TestMethod]
+        public void SetFolder_IdsPath_ValidationPasses_ReturnsTrue()
+        {
+            consoleAppHelper.Setup(n =>
+                n.ValidateHubAccessAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, (string)null));
+
+            var region = "US";
+            consoleAppHelper.Setup(n => n.GetRegion(It.IsAny<string>(), out region));
+
+            var setFolder = new SetFolderCommand(consoleAppHelper.Object);
+            setFolder.GetOption<HubId>().SetValue("b.valid-hub-id");
+            setFolder.GetOption<Region>().SetValue("US");
+            setFolder.GetOption<ProjectUrn>().SetValue("b.valid-project");
+            setFolder.GetOption<FolderUrn>().SetValue("urn:adsk.wipprod:fs.folder:co.test");
+
+            var task = setFolder.Execute();
+            task.Wait();
+            Assert.AreEqual(true, task.Result);
+
+            consoleAppHelper.Verify(
+                n => n.SetFolder(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+                Times.Once());
+        }
+
+        [TestMethod]
+        public void SetFolder_IdsPath_MissingFields_ReturnsFalse()
+        {
+            var setFolder = new SetFolderCommand(consoleAppHelper.Object);
+            setFolder.GetOption<HubId>().SetValue("b.hub-id");
+            // Region is not set, ProjectUrn is not set, FolderUrn is not set
+
+            var task = setFolder.Execute();
+            task.Wait();
+            Assert.AreEqual(false, task.Result);
+
+            consoleAppHelper.Verify(
+                n => n.SetFolder(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never());
+        }
+
+        [TestMethod]
+        public void SetFolder_UrlPath_MalformedUrl_ReturnsFalse()
+        {
+            var setFolder = new SetFolderCommand(consoleAppHelper.Object);
+            setFolder.GetOption<HubId>().SetValue("https://not-a-valid-url");
+
+            var task = setFolder.Execute();
+            task.Wait();
+            Assert.AreEqual(false, task.Result);
+
+            consoleAppHelper.Verify(
+                n => n.SetFolder(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never());
+        }
+
+        [TestMethod]
+        public void SetFolder_UrlPath_HubIdResolutionFails_ReturnsFalse()
+        {
+            var emptyHubId = (string)null;
+            consoleAppHelper.Setup(n => n.GetHubId(It.IsAny<string>(), out emptyHubId));
+
+            var setFolder = new SetFolderCommand(consoleAppHelper.Object);
+            setFolder.GetOption<HubId>().SetValue(
+                "https://acc.autodesk.com/docs/files/projects/e3be8c87-1df5-470f-9214-1b6cc85452fa?folderUrn=urn%3Aadsk.wipprod%3Afs.folder%3Aco.NBWiKlvJSqOo1B4iUajHeA&viewModel=detail");
+
+            var task = setFolder.Execute();
+            task.Wait();
+            Assert.AreEqual(false, task.Result);
+
+            consoleAppHelper.Verify(
+                n => n.SetFolder(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never());
+        }
+
+        [TestMethod]
+        public void SetFolder_UrlPath_RegionResolutionFails_ReturnsFalse()
+        {
+            var hubId = "b.valid-hub";
+            consoleAppHelper.Setup(n => n.GetHubId(It.IsAny<string>(), out hubId));
+
+            var emptyRegion = (string)null;
+            consoleAppHelper.Setup(n => n.GetRegion(It.IsAny<string>(), out emptyRegion));
+
+            var setFolder = new SetFolderCommand(consoleAppHelper.Object);
+            setFolder.GetOption<HubId>().SetValue(
+                "https://acc.autodesk.com/docs/files/projects/e3be8c87-1df5-470f-9214-1b6cc85452fa?folderUrn=urn%3Aadsk.wipprod%3Afs.folder%3Aco.NBWiKlvJSqOo1B4iUajHeA&viewModel=detail");
+
+            var task = setFolder.Execute();
+            task.Wait();
+            Assert.AreEqual(false, task.Result);
+
+            consoleAppHelper.Verify(
+                n => n.SetFolder(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never());
+        }
+
+        [TestMethod]
+        public void SetFolder_UrlPath_Success_ReturnsTrue()
+        {
+            var hubId = "b.valid-hub";
+            consoleAppHelper.Setup(n => n.GetHubId(It.IsAny<string>(), out hubId));
+
+            var region = "US";
+            consoleAppHelper.Setup(n => n.GetRegion(It.IsAny<string>(), out region));
+
+            var setFolder = new SetFolderCommand(consoleAppHelper.Object);
+            setFolder.GetOption<HubId>().SetValue(
+                "https://acc.autodesk.com/docs/files/projects/e3be8c87-1df5-470f-9214-1b6cc85452fa?folderUrn=urn%3Aadsk.wipprod%3Afs.folder%3Aco.NBWiKlvJSqOo1B4iUajHeA&viewModel=detail");
+
+            var task = setFolder.Execute();
+            task.Wait();
+            Assert.AreEqual(true, task.Result);
+
+            consoleAppHelper.Verify(
+                n => n.SetFolder("US", "b.valid-hub",
+                    "b.e3be8c87-1df5-470f-9214-1b6cc85452fa",
+                    "urn:adsk.wipprod:fs.folder:co.NBWiKlvJSqOo1B4iUajHeA"),
+                Times.Once());
+        }
+
+        [TestMethod]
+        public void CreateExchange_MissingFolderDetails_ReturnsFalse()
+        {
+            consoleAppHelper.Setup(n =>
+                n.TryGetFolderDetails(out It.Ref<string>.IsAny, out It.Ref<string>.IsAny, out It.Ref<string>.IsAny, out It.Ref<string>.IsAny))
+                .Returns(true);
+
+            var createExchange = new CreateExchangeCommand(consoleAppHelper.Object);
+            createExchange.GetOption<ExchangeTitle>().SetValue("TestExchange");
+            var task = createExchange.Execute();
+            task.Wait();
+
+            Assert.AreEqual(false, task.Result);
+        }
+
     }
 }

--- a/test/ConsoleConnector_Test/Command_Test.cs
+++ b/test/ConsoleConnector_Test/Command_Test.cs
@@ -111,7 +111,7 @@ namespace ConsoleConnector_Test
                 n.ValidateHubAccessAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((false, "[ERROR] Unable to resolve HubId for ProjectUrn 'b.wrong-id'. " +
                     "This usually means your app's ClientId has not been added to the Forma/ACC hub " +
-                    "as a custom integration (Step 1c in setup), or the ProjectUrn does not exist."));
+                    "as a custom integration (via Hub Admin > Custom Integrations), or the ProjectUrn does not exist."));
 
             var setFolder = new SetFolderCommand(consoleAppHelper.Object);
             setFolder.GetOption<HubId>().SetValue("b.wrong-hub-id");


### PR DESCRIPTION
## Summary

- **Input validation**: SetFolderCommand now reports exactly which required fields (HubId, Region, ProjectUrn, FolderUrn) are missing instead of a generic 'Invalid inputs' message
- **Hub access validation**: Added `ValidateHubAccessAsync` to verify the app's ClientId is registered as a custom integration in the Forma/ACC hub before proceeding, with actionable error messages referencing setup steps
- **Region mismatch detection**: When the user-provided region differs from the resolved region, a warning is displayed and the resolved region is used automatically
- **URL parsing resilience**: `ExecuteWithUrl` now wraps URL parsing in try-catch with specific error messages for each extraction failure (ProjectUrn, FolderUrn, HubId, Region)
- **Robust GetHubId / GetRegion**: Both methods now catch exceptions, check for null/empty responses, and print actionable diagnostics instead of throwing unhandled exceptions
- **CreateExchange guard**: Throws a descriptive `InvalidOperationException` when folder details are missing, guiding the user to run `SetFolder` first
- **Project info warning**: Logs a warning when project information cannot be retrieved during exchange creation

## Test plan

- [x] Added unit tests for SetFolder ID-path validation failure
- [x] Added unit tests for SetFolder ID-path validation success
- [x] Added unit tests for SetFolder ID-path missing fields
- [x] Added unit tests for SetFolder URL-path malformed URL
- [x] Added unit tests for SetFolder URL-path HubId resolution failure
- [x] Added unit tests for SetFolder URL-path Region resolution failure
- [x] Added unit tests for SetFolder URL-path success (end-to-end)
- [x] Added unit test for CreateExchange with missing folder details