### PR TITLE
Improve SetFolder validation, error handling, and async patterns

### DIFF
--- a/src/ConsoleConnector/Commands/SetFolderCommand.cs
+++ b/src/ConsoleConnector/Commands/SetFolderCommand.cs
@@ -36,57 +36,116 @@ namespace Autodesk.DataExchange.ConsoleApp.Commands
             return new SetFolderCommand(this);
         }
 
-        public override Task<bool> Execute()
+        public override async Task<bool> Execute()
         {
             var check = this.GetOption<HubId>().Value;
-            if (check!=null && check.Contains("http"))
+            if (check != null && check.Contains("http"))
             {
-                return Execute(check);
+                return await ExecuteWithUrl(check);
             }
             if (this.ValidateOptions() == false)
             {
-                Console.WriteLine("Invalid inputs!!!");
-                return Task.FromResult(false);
+                var missing = new List<string>();
+                if (!this.GetOption<HubId>().IsValid()) missing.Add("HubId");
+                if (!this.GetOption<Region>().IsValid()) missing.Add("Region");
+                if (!this.GetOption<ProjectUrn>().IsValid()) missing.Add("ProjectUrn");
+                if (!this.GetOption<FolderUrn>().IsValid()) missing.Add("FolderUrn");
+                Console.WriteLine($"[ERROR] Invalid inputs. Missing required fields: {string.Join(", ", missing)}");
+                return false;
             }
             var hubId = this.GetOption<HubId>();
             var region = this.GetOption<Region>();
             var projectUrn = this.GetOption<ProjectUrn>();
             var folderUrn = this.GetOption<FolderUrn>();
-            ConsoleAppHelper.SetFolder(region.Value,hubId.Value,projectUrn.Value,folderUrn.Value);
+
+            var validation = await ConsoleAppHelper.ValidateHubAccessAsync(hubId.Value, projectUrn.Value);
+            if (!validation.IsValid)
+            {
+                Console.WriteLine(validation.ErrorMessage);
+                return false;
+            }
+
+            var effectiveRegion = region.Value;
+            if (!string.IsNullOrEmpty(validation.ResolvedRegion) &&
+                !string.Equals(region.Value, validation.ResolvedRegion, StringComparison.OrdinalIgnoreCase))
+            {
+                Console.WriteLine($"[WARNING] Provided region '{region.Value}' differs from the resolved region '{validation.ResolvedRegion}'. Using resolved region.");
+                effectiveRegion = validation.ResolvedRegion;
+            }
+            ConsoleAppHelper.SetFolder(effectiveRegion, hubId.Value, projectUrn.Value, folderUrn.Value);
             Console.WriteLine("Default folder set!!!");
-            return Task.FromResult(true);
+            return true;
         }
 
-        private Task<bool> Execute(string folderUrl)
+        private async Task<bool> ExecuteWithUrl(string folderUrl)
         {
-            var projectUrn = "b." + folderUrl.ToString().Split('/')[6].Split('?')[0];
-            var folderUrn = folderUrl.ToString().Split('/')[6].Split('?')[1].Split('&')[0].Split('=')[1].Replace("%3A", ":");
+            string projectUrn;
+            string folderUrn;
+            try
+            {
+                projectUrn = "b." + folderUrl.Split('/')[6].Split('?')[0];
+                folderUrn = folderUrl.Split('/')[6].Split('?')[1].Split('&')[0].Split('=')[1].Replace("%3A", ":");
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("[ERROR] The provided URL format is not recognized. Expected a Forma/ACC folder URL.");
+                return false;
+            }
 
-            ConsoleAppHelper.GetHubId(projectUrn, out string hubId);
-            if (string.IsNullOrEmpty(hubId))
+            if (string.IsNullOrEmpty(projectUrn) || projectUrn == "b.")
             {
-                Console.WriteLine("Invalid FolderUrl!!!");
-                return Task.FromResult(false);
+                Console.WriteLine("[ERROR] Could not extract ProjectUrn from the URL. Please verify the URL format.");
+                return false;
             }
-            ConsoleAppHelper.GetRegion(hubId, out string region);
-            if (string.IsNullOrEmpty(region)) 
-            {
-                Console.WriteLine("Invalid FolderUrl!!!");
-                return Task.FromResult(false);
-            }
+
             if (string.IsNullOrEmpty(folderUrn))
             {
-                Console.WriteLine("Invalid FolderUrl!!!");
-                return Task.FromResult(false);
+                Console.WriteLine("[ERROR] Could not extract FolderUrn from the URL. Please verify the URL contains a valid folderUrn query parameter.");
+                return false;
             }
-            if (string.IsNullOrEmpty(projectUrn))
+
+            string hubId = null;
+            try
             {
-                Console.WriteLine("Invalid FolderUrl!!!");
-                return Task.FromResult(false);
+                var hubIdResponse = await ConsoleAppHelper.GetHubIdAsync(projectUrn);
+                if (hubIdResponse != null && hubIdResponse.IsSuccess && !string.IsNullOrEmpty(hubIdResponse.Value))
+                {
+                    hubId = hubIdResponse.Value;
+                }
             }
+            catch (Exception)
+            {
+                hubId = null;
+            }
+
+            if (string.IsNullOrEmpty(hubId))
+            {
+                Console.WriteLine(
+                    $"[ERROR] Unable to resolve HubId from the folder URL. " +
+                    "This usually means your app's ClientId has not been added to the Forma/ACC hub " +
+                    $"as a custom integration, or the project in the URL does not exist. (ProjectUrn: '{projectUrn}')");
+                return false;
+            }
+
+            string region = null;
+            try
+            {
+                region = await ConsoleAppHelper.GetRegionAsync(hubId);
+            }
+            catch (Exception)
+            {
+                region = null;
+            }
+
+            if (string.IsNullOrEmpty(region))
+            {
+                Console.WriteLine($"[ERROR] Unable to resolve region for the hub. The HubId '{hubId}' may be invalid or inaccessible.");
+                return false;
+            }
+
             ConsoleAppHelper.SetFolder(region, hubId, projectUrn, folderUrn);
             Console.WriteLine("Default folder set!!!");
-            return Task.FromResult(true);
+            return true;
         }
     }
 }

--- a/src/ConsoleConnector/Helper/ConsoleAppHelper.cs
+++ b/src/ConsoleConnector/Helper/ConsoleAppHelper.cs
@@ -92,12 +92,77 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
 
         public void GetHubId(string projectUrn, out string hubId)
         {
-            hubId = GetHubIdAsync(projectUrn).Result.Value;
+            hubId = null;
+            try
+            {
+                var response = GetHubIdAsync(projectUrn).Result;
+                if (response != null && response.IsSuccess && !string.IsNullOrEmpty(response.Value))
+                {
+                    hubId = response.Value;
+                }
+            }
+            catch (Exception)
+            {
+                hubId = null;
+            }
         }
 
         public void GetRegion(string hubId, out string region)
         {
-            region = GetRegionAsync(hubId).Result;
+            region = null;
+            try
+            {
+                region = GetRegionAsync(hubId).Result;
+            }
+            catch (Exception)
+            {
+                region = null;
+            }
+        }
+
+        public async Task<(bool IsValid, string ErrorMessage, string ResolvedRegion)> ValidateHubAccessAsync(string hubId, string projectUrn)
+        {
+            try
+            {
+                var hubIdResponse = await Client.GetHubIdAsync(projectUrn);
+                if (hubIdResponse == null || string.IsNullOrEmpty(hubIdResponse.Value))
+                {
+                    return (false,
+                        $"[ERROR] Unable to resolve HubId for ProjectUrn '{projectUrn}'. " +
+                        "This usually means your app's ClientId has not been added to the Forma/ACC hub " +
+                        "as a custom integration (via Hub Admin > Custom Integrations), or the ProjectUrn does not exist.",
+                        null);
+                }
+
+                var resolvedHubId = hubIdResponse.Value;
+                if (!string.IsNullOrEmpty(hubId) && !string.Equals(hubId, resolvedHubId, StringComparison.OrdinalIgnoreCase))
+                {
+                    return (false,
+                        $"[ERROR] Provided HubId '{hubId}' does not match the HubId resolved from ProjectUrn ('{resolvedHubId}'). " +
+                        "Please verify your HubId is correct.",
+                        null);
+                }
+
+                var resolvedRegion = await Client.SDKOptions.HostingProvider.GetRegionAsync(
+                    string.IsNullOrEmpty(hubId) ? resolvedHubId : hubId);
+                if (string.IsNullOrEmpty(resolvedRegion))
+                {
+                    return (false,
+                        $"[ERROR] Unable to resolve region for HubId '{hubId}'. " +
+                        "Verify the HubId is correct and your app has the required permissions.",
+                        null);
+                }
+
+                return (true, null, resolvedRegion);
+            }
+            catch (Exception ex)
+            {
+                return (false,
+                    $"[ERROR] Hub access validation failed: {ex.Message}. " +
+                    "Verify that your app's ClientId has been added to the Forma/ACC hub as a custom integration " +
+                    "and that you have the required permissions (Data Exchange API, Data Management API).",
+                    null);
+            }
         }
 
         public ElementDataModel GetExchangeData(string exchangeTitle)
@@ -175,6 +240,11 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
             this.SaveFolderDetails();
         }
 
+        /// <summary>
+        /// NOTE: Returns true when folder details are MISSING (inverted from typical .NET Try* convention).
+        /// A return value of true means at least one required field is null/empty.
+        /// A return value of false means all folder details are present.
+        /// </summary>
         public bool TryGetFolderDetails(out string region, out string hubId, out string projectUrn,
             out string folderUrn)
         {
@@ -271,6 +341,11 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
             if (projectDetails != null)
             {
                 projectType = projectDetails.ProjectType;
+            }
+            else
+            {
+                Console.WriteLine($"[WARNING] Could not retrieve project information for HubId '{hubId}' and ProjectUrn '{projectUrn}'. " +
+                    "This may indicate incorrect folder details or insufficient permissions.");
             }
 
             var exchangeCreateRequest = new ExchangeCreateRequestACC()

--- a/src/ConsoleConnector/Interfaces/IConsoleAppHelper.cs
+++ b/src/ConsoleConnector/Interfaces/IConsoleAppHelper.cs
@@ -30,6 +30,9 @@ namespace Autodesk.DataExchange.ConsoleApp.Interfaces
         Task<IResponse<ExchangeDetails>> CreateExchange(string exchangeTitle);
         void GetHubId(string projectUrn, out string hubId);
         void GetRegion(string hubId, out string region);
+        Task<IResponse<string>> GetHubIdAsync(string projectUrn);
+        Task<string> GetRegionAsync(string hubId);
+        Task<(bool IsValid, string ErrorMessage, string ResolvedRegion)> ValidateHubAccessAsync(string hubId, string projectUrn);
         Task<bool> SyncExchange(DataExchangeIdentifier dataExchangeIdentifier,ExchangeDetails exchangeDetails, ElementDataModel exchangeData);
 
         IClient GetClient();

--- a/test/ConsoleConnector_Test/Command_Test.cs
+++ b/test/ConsoleConnector_Test/Command_Test.cs
@@ -103,5 +103,191 @@ namespace ConsoleConnector_Test
             task.Wait();
             Assert.AreEqual(task.Result, true);
         }
+
+        [TestMethod]
+        public void SetFolder_IdsPath_ValidationFails_ReturnsFalse()
+        {
+            consoleAppHelper.Setup(n =>
+                n.ValidateHubAccessAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((false, "validation failed", (string)null));
+
+            var setFolder = new SetFolderCommand(consoleAppHelper.Object);
+            setFolder.GetOption<HubId>().SetValue("b.wrong-hub-id");
+            setFolder.GetOption<Region>().SetValue("US");
+            setFolder.GetOption<ProjectUrn>().SetValue("b.wrong-id");
+            setFolder.GetOption<FolderUrn>().SetValue("urn:adsk.wipprod:fs.folder:co.test");
+
+            var task = setFolder.Execute();
+            task.Wait();
+            Assert.AreEqual(false, task.Result);
+
+            consoleAppHelper.Verify(
+                n => n.SetFolder(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never());
+        }
+
+        [TestMethod]
+        public void SetFolder_IdsPath_ValidationPasses_ReturnsTrue()
+        {
+            consoleAppHelper.Setup(n =>
+                n.ValidateHubAccessAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, (string)null, "US"));
+
+            var setFolder = new SetFolderCommand(consoleAppHelper.Object);
+            setFolder.GetOption<HubId>().SetValue("b.valid-hub-id");
+            setFolder.GetOption<Region>().SetValue("US");
+            setFolder.GetOption<ProjectUrn>().SetValue("b.valid-project");
+            setFolder.GetOption<FolderUrn>().SetValue("urn:adsk.wipprod:fs.folder:co.test");
+
+            var task = setFolder.Execute();
+            task.Wait();
+            Assert.AreEqual(true, task.Result);
+
+            consoleAppHelper.Verify(
+                n => n.SetFolder(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+                Times.Once());
+        }
+
+        [TestMethod]
+        public void SetFolder_IdsPath_RegionMismatch_UsesResolvedRegion()
+        {
+            consoleAppHelper.Setup(n =>
+                n.ValidateHubAccessAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, (string)null, "EMEA"));
+
+            var setFolder = new SetFolderCommand(consoleAppHelper.Object);
+            setFolder.GetOption<HubId>().SetValue("b.valid-hub-id");
+            setFolder.GetOption<Region>().SetValue("US");
+            setFolder.GetOption<ProjectUrn>().SetValue("b.valid-project");
+            setFolder.GetOption<FolderUrn>().SetValue("urn:adsk.wipprod:fs.folder:co.test");
+
+            var task = setFolder.Execute();
+            task.Wait();
+            Assert.AreEqual(true, task.Result);
+
+            consoleAppHelper.Verify(
+                n => n.SetFolder("EMEA", "b.valid-hub-id", "b.valid-project", "urn:adsk.wipprod:fs.folder:co.test"),
+                Times.Once());
+        }
+
+        [TestMethod]
+        public void SetFolder_IdsPath_MissingFields_ReturnsFalse()
+        {
+            var setFolder = new SetFolderCommand(consoleAppHelper.Object);
+            setFolder.GetOption<HubId>().SetValue("b.hub-id");
+
+            var task = setFolder.Execute();
+            task.Wait();
+            Assert.AreEqual(false, task.Result);
+
+            consoleAppHelper.Verify(
+                n => n.SetFolder(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never());
+        }
+
+        [TestMethod]
+        public void SetFolder_UrlPath_MalformedUrl_ReturnsFalse()
+        {
+            var setFolder = new SetFolderCommand(consoleAppHelper.Object);
+            setFolder.GetOption<HubId>().SetValue("https://not-a-valid-url");
+
+            var task = setFolder.Execute();
+            task.Wait();
+            Assert.AreEqual(false, task.Result);
+
+            consoleAppHelper.Verify(
+                n => n.SetFolder(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never());
+        }
+
+        [TestMethod]
+        public void SetFolder_UrlPath_HubIdResolutionFails_ReturnsFalse()
+        {
+            var failedResponse = new Mock<IResponse<string>>();
+            failedResponse.SetupGet(x => x.IsSuccess).Returns(false);
+            failedResponse.SetupGet(x => x.Value).Returns((string)null);
+            consoleAppHelper.Setup(n => n.GetHubIdAsync(It.IsAny<string>()))
+                .ReturnsAsync(failedResponse.Object);
+
+            var setFolder = new SetFolderCommand(consoleAppHelper.Object);
+            setFolder.GetOption<HubId>().SetValue(
+                "https://acc.autodesk.com/docs/files/projects/e3be8c87-1df5-470f-9214-1b6cc85452fa?folderUrn=urn%3Aadsk.wipprod%3Afs.folder%3Aco.NBWiKlvJSqOo1B4iUajHeA&viewModel=detail");
+
+            var task = setFolder.Execute();
+            task.Wait();
+            Assert.AreEqual(false, task.Result);
+
+            consoleAppHelper.Verify(
+                n => n.SetFolder(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never());
+        }
+
+        [TestMethod]
+        public void SetFolder_UrlPath_RegionResolutionFails_ReturnsFalse()
+        {
+            var successResponse = new Mock<IResponse<string>>();
+            successResponse.SetupGet(x => x.IsSuccess).Returns(true);
+            successResponse.SetupGet(x => x.Value).Returns("b.valid-hub");
+            consoleAppHelper.Setup(n => n.GetHubIdAsync(It.IsAny<string>()))
+                .ReturnsAsync(successResponse.Object);
+
+            consoleAppHelper.Setup(n => n.GetRegionAsync(It.IsAny<string>()))
+                .ReturnsAsync((string)null);
+
+            var setFolder = new SetFolderCommand(consoleAppHelper.Object);
+            setFolder.GetOption<HubId>().SetValue(
+                "https://acc.autodesk.com/docs/files/projects/e3be8c87-1df5-470f-9214-1b6cc85452fa?folderUrn=urn%3Aadsk.wipprod%3Afs.folder%3Aco.NBWiKlvJSqOo1B4iUajHeA&viewModel=detail");
+
+            var task = setFolder.Execute();
+            task.Wait();
+            Assert.AreEqual(false, task.Result);
+
+            consoleAppHelper.Verify(
+                n => n.SetFolder(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never());
+        }
+
+        [TestMethod]
+        public void SetFolder_UrlPath_Success_ReturnsTrue()
+        {
+            var successResponse = new Mock<IResponse<string>>();
+            successResponse.SetupGet(x => x.IsSuccess).Returns(true);
+            successResponse.SetupGet(x => x.Value).Returns("b.valid-hub");
+            consoleAppHelper.Setup(n => n.GetHubIdAsync(It.IsAny<string>()))
+                .ReturnsAsync(successResponse.Object);
+
+            consoleAppHelper.Setup(n => n.GetRegionAsync(It.IsAny<string>()))
+                .ReturnsAsync("US");
+
+            var setFolder = new SetFolderCommand(consoleAppHelper.Object);
+            setFolder.GetOption<HubId>().SetValue(
+                "https://acc.autodesk.com/docs/files/projects/e3be8c87-1df5-470f-9214-1b6cc85452fa?folderUrn=urn%3Aadsk.wipprod%3Afs.folder%3Aco.NBWiKlvJSqOo1B4iUajHeA&viewModel=detail");
+
+            var task = setFolder.Execute();
+            task.Wait();
+            Assert.AreEqual(true, task.Result);
+
+            consoleAppHelper.Verify(
+                n => n.SetFolder("US", "b.valid-hub",
+                    "b.e3be8c87-1df5-470f-9214-1b6cc85452fa",
+                    "urn:adsk.wipprod:fs.folder:co.NBWiKlvJSqOo1B4iUajHeA"),
+                Times.Once());
+        }
+
+        [TestMethod]
+        public void CreateExchange_MissingFolderDetails_ReturnsFalse()
+        {
+            consoleAppHelper.Setup(n =>
+                n.TryGetFolderDetails(out It.Ref<string>.IsAny, out It.Ref<string>.IsAny, out It.Ref<string>.IsAny, out It.Ref<string>.IsAny))
+                .Returns(true);
+
+            var createExchange = new CreateExchangeCommand(consoleAppHelper.Object);
+            createExchange.GetOption<ExchangeTitle>().SetValue("TestExchange");
+            var task = createExchange.Execute();
+            task.Wait();
+
+            Assert.AreEqual(false, task.Result);
+        }
+
     }
 }


### PR DESCRIPTION
## Summary

- **Actionable error messages**: Replace generic 'Invalid inputs!!!' and 'Invalid FolderUrl!!!' with specific diagnostics that tell the user exactly what went wrong and how to fix it (missing fields, hub access issues, URL parsing failures)
- **Hub access validation**: Add `ValidateHubAccessAsync` that verifies hub access and resolves region in a single call, eliminating the redundant second API round-trip that previously existed
- **Async cleanup**: Convert `ExecuteWithUrl` from sync-over-async (`.Result`) to proper `async/await`, removing deadlock risk. Expose `GetHubIdAsync`/`GetRegionAsync` on `IConsoleAppHelper` so callers can use async paths directly
- **Single-responsibility error logging**: `GetHubId`/`GetRegion` helpers no longer print error messages themselves; callers own the messaging with full context (URL vs IDs flow), preventing double error output
- **Region mismatch detection**: When user-provided region differs from the resolved region, a warning is logged and the resolved region is used automatically
- **CreateExchange guard**: `CreateExchangeCommand` already checks folder details before calling `CreateExchange`; a warning is now emitted when project info retrieval fails
- **TryGetFolderDetails documentation**: Added XML doc comment explaining the inverted return convention (returns `true` when details are missing)

## Test plan

- [x] SetFolder ID-path: validation failure returns false, `SetFolder` never called
- [x] SetFolder ID-path: validation passes, `SetFolder` called once
- [x] SetFolder ID-path: region mismatch uses resolved region (EMEA vs US)
- [x] SetFolder ID-path: missing required fields returns false
- [x] SetFolder URL-path: malformed URL returns false
- [x] SetFolder URL-path: HubId resolution failure returns false
- [x] SetFolder URL-path: Region resolution failure returns false
- [x] SetFolder URL-path: success end-to-end with exact argument verification
- [x] CreateExchange: missing folder details returns false