### PR TITLE
Upgrade sample to DXSDK 7.5.0-beta

### DIFF
--- a/src/ConsoleConnector/Commands/SyncExchangeGeometry.cs
+++ b/src/ConsoleConnector/Commands/SyncExchangeGeometry.cs
@@ -82,8 +82,8 @@ namespace Autodesk.DataExchange.ConsoleApp.Commands
             };
 
             await ConsoleAppHelper.Client.SyncExchangeDataAsync(exchangeIdentifier, exchangeData);
-            await ConsoleAppHelper.Client.GenerateViewableAsync(exchangeDetails.DisplayName, exchangeDetails.ExchangeID,
-                exchangeDetails.CollectionID, exchangeDetails.FileUrn);
+            // Viewable generation is handled server-side in SDK 7.5.0; the client-side
+            // Client.GenerateViewableAsync API was removed (no replacement).
             ConsoleAppHelper.SetExchangeUpdated(exchangeTitle.Value,false);
             var exchangeDetails2 = await ConsoleAppHelper.Client.GetExchangeDetailsAsync(exchangeIdentifier);
             exchangeDetails.FileVersionUrn = exchangeDetails2.FileVersionUrn;

--- a/src/ConsoleConnector/ConsoleConnector.csproj
+++ b/src/ConsoleConnector/ConsoleConnector.csproj
@@ -61,7 +61,7 @@
       <HintPath>..\..\packages\AngleSharp.1.2.0\lib\net472\AngleSharp.dll</HintPath>
     </Reference>
     <Reference Include="Autodesk.DataExchange, Version=7.5.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\lib\net48\Autodesk.DataExchange.dll</HintPath>
+      <HintPath>..\..\packages\Autodesk.DataExchange.7.5.0-beta\lib\net48\Autodesk.DataExchange.dll</HintPath>
     </Reference>
     <Reference Include="Autodesk.GeometryUtilities.PrimitivesAPI, Version=0.9.3.0, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.9.3\lib\net48\Autodesk.GeometryUtilities.PrimitivesAPI.dll</HintPath>
@@ -477,10 +477,10 @@
     <Error Condition="!Exists('..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets'))" />
     <Error Condition="!Exists('..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\build\Autodesk.DataExchange.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\build\Autodesk.DataExchange.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Autodesk.DataExchange.7.5.0-beta\build\Autodesk.DataExchange.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Autodesk.DataExchange.7.5.0-beta\build\Autodesk.DataExchange.targets'))" />
   </Target>
   <Import Project="..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets" Condition="Exists('..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets')" />
   <Import Project="..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets" Condition="Exists('..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets')" />
   <Import Project="..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets" Condition="Exists('..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets')" />
-  <Import Project="..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\build\Autodesk.DataExchange.targets" Condition="Exists('..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\build\Autodesk.DataExchange.targets')" />
+  <Import Project="..\..\packages\Autodesk.DataExchange.7.5.0-beta\build\Autodesk.DataExchange.targets" Condition="Exists('..\..\packages\Autodesk.DataExchange.7.5.0-beta\build\Autodesk.DataExchange.targets')" />
 </Project>

--- a/src/ConsoleConnector/ConsoleConnector.csproj
+++ b/src/ConsoleConnector/ConsoleConnector.csproj
@@ -60,14 +60,14 @@
     <Reference Include="AngleSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
       <HintPath>..\..\packages\AngleSharp.1.2.0\lib\net472\AngleSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange, Version=7.4.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.7.4.0-beta\lib\net48\Autodesk.DataExchange.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange, Version=7.5.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\lib\net48\Autodesk.DataExchange.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.GeometryPrimitives.Data, Version=0.7.22.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.10\lib\net48\Autodesk.GeometryPrimitives.Data.dll</HintPath>
+    <Reference Include="Autodesk.GeometryUtilities.PrimitivesAPI, Version=0.9.3.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.9.3\lib\net48\Autodesk.GeometryUtilities.PrimitivesAPI.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.GeometryUtilities.MeshAPI, Version=0.7.22.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.10\lib\net48\Autodesk.GeometryUtilities.MeshAPI.dll</HintPath>
+    <Reference Include="Autodesk.GeometryUtilities.MeshAPI, Version=0.9.3.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.9.3\lib\net48\Autodesk.GeometryUtilities.MeshAPI.dll</HintPath>
     </Reference>
     <Reference Include="Autodesk.Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Autodesk.Newtonsoft.Json.13.0.3\lib\net45\Autodesk.Newtonsoft.Json.dll</HintPath>
@@ -477,10 +477,10 @@
     <Error Condition="!Exists('..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets'))" />
     <Error Condition="!Exists('..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Autodesk.DataExchange.7.4.0-beta\build\Autodesk.DataExchange.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Autodesk.DataExchange.7.4.0-beta\build\Autodesk.DataExchange.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\build\Autodesk.DataExchange.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\build\Autodesk.DataExchange.targets'))" />
   </Target>
   <Import Project="..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets" Condition="Exists('..\..\packages\ForgeUnits-csharp_win_release_intel64_v140.5.1.4\build\ForgeUnits-csharp_win_release_intel64_v140.targets')" />
   <Import Project="..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets" Condition="Exists('..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets')" />
   <Import Project="..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets" Condition="Exists('..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets')" />
-  <Import Project="..\..\packages\Autodesk.DataExchange.7.4.0-beta\build\Autodesk.DataExchange.targets" Condition="Exists('..\..\packages\Autodesk.DataExchange.7.4.0-beta\build\Autodesk.DataExchange.targets')" />
+  <Import Project="..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\build\Autodesk.DataExchange.targets" Condition="Exists('..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\build\Autodesk.DataExchange.targets')" />
 </Project>

--- a/src/ConsoleConnector/Helper/ConsoleAppHelper.cs
+++ b/src/ConsoleConnector/Helper/ConsoleAppHelper.cs
@@ -418,8 +418,8 @@ namespace Autodesk.DataExchange.ConsoleApp.Helper
         public async Task<bool> SyncExchange(DataExchangeIdentifier dataExchangeIdentifier, ExchangeDetails exchangeDetails, ElementDataModel exchangeData)
         {
             await Client.SyncExchangeDataAsync(dataExchangeIdentifier, exchangeData);
-            await Client.GenerateViewableAsync(exchangeDetails.ExchangeID,
-                exchangeDetails.CollectionID);
+            // Viewable generation is handled server-side in SDK 7.5.0; the client-side
+            // Client.GenerateViewableAsync API was removed (no replacement).
             return true;
         }
 

--- a/src/ConsoleConnector/Helper/GeometryHelper.cs
+++ b/src/ConsoleConnector/Helper/GeometryHelper.cs
@@ -1,7 +1,7 @@
 using Autodesk.DataExchange.Core.Enums;
 using Autodesk.DataExchange.DataModels;
-using Autodesk.GeometryPrimitives.Data;
-using Autodesk.GeometryPrimitives.Data.DX;
+using Autodesk.GeometryUtilities.PrimitivesAPI;
+using Autodesk.GeometryUtilities.PrimitivesAPI.DX;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/ConsoleConnector/packages.config
+++ b/src/ConsoleConnector/packages.config
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AngleSharp" version="1.2.0" targetFramework="net48" />
-  <package id="Autodesk.DataExchange" version="7.5.0-alpha.3" targetFramework="net48" />
+  <package id="Autodesk.DataExchange" version="7.5.0-beta" targetFramework="net48" />
   <package id="Autodesk.DataExchange.GeometryDefinitions" version="0.9.3" targetFramework="net48" />
   <package id="Autodesk.Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
   <package id="ForgeParameters-csharp_win_release_intel64_v140" version="3.0.6" targetFramework="net48" />

--- a/src/ConsoleConnector/packages.config
+++ b/src/ConsoleConnector/packages.config
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AngleSharp" version="1.2.0" targetFramework="net48" />
-  <package id="Autodesk.DataExchange" version="7.4.0-beta" targetFramework="net48" />
-  <package id="Autodesk.DataExchange.GeometryDefinitions" version="0.1.10" targetFramework="net48" />
+  <package id="Autodesk.DataExchange" version="7.5.0-alpha.3" targetFramework="net48" />
+  <package id="Autodesk.DataExchange.GeometryDefinitions" version="0.9.3" targetFramework="net48" />
   <package id="Autodesk.Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
   <package id="ForgeParameters-csharp_win_release_intel64_v140" version="3.0.6" targetFramework="net48" />
   <package id="ForgeUnits-csharp_win_release_intel64_v140" version="5.1.4" targetFramework="net48" />

--- a/test/ConsoleConnector_Test/ConsoleConnector_Test.csproj
+++ b/test/ConsoleConnector_Test/ConsoleConnector_Test.csproj
@@ -63,15 +63,15 @@
     <Reference Include="AngleSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
       <HintPath>..\..\packages\AngleSharp.1.2.0\lib\net472\AngleSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.DataExchange, Version=7.4.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.7.4.0-beta\lib\net48\Autodesk.DataExchange.dll</HintPath>
+    <Reference Include="Autodesk.DataExchange, Version=7.5.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\lib\net48\Autodesk.DataExchange.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Autodesk.GeometryPrimitives.Data, Version=0.7.22.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.10\lib\net48\Autodesk.GeometryPrimitives.Data.dll</HintPath>
+    <Reference Include="Autodesk.GeometryUtilities.PrimitivesAPI, Version=0.9.3.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.9.3\lib\net48\Autodesk.GeometryUtilities.PrimitivesAPI.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.GeometryUtilities.MeshAPI, Version=0.7.22.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.1.10\lib\net48\Autodesk.GeometryUtilities.MeshAPI.dll</HintPath>
+    <Reference Include="Autodesk.GeometryUtilities.MeshAPI, Version=0.9.3.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.9.3\lib\net48\Autodesk.GeometryUtilities.MeshAPI.dll</HintPath>
     </Reference>
     <Reference Include="Autodesk.Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Autodesk.Newtonsoft.Json.13.0.3\lib\net45\Autodesk.Newtonsoft.Json.dll</HintPath>
@@ -458,12 +458,12 @@
     <Error Condition="!Exists('..\..\packages\Microsoft.Testing.Extensions.Telemetry.1.7.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Testing.Extensions.Telemetry.1.7.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props'))" />
     <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.3.9.3\build\net462\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.3.9.3\build\net462\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.3.9.3\build\net462\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.3.9.3\build\net462\MSTest.TestAdapter.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Autodesk.DataExchange.7.4.0-beta\build\Autodesk.DataExchange.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Autodesk.DataExchange.7.4.0-beta\build\Autodesk.DataExchange.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\build\Autodesk.DataExchange.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\build\Autodesk.DataExchange.targets'))" />
   </Target>
   <Import Project="..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets" Condition="Exists('..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets')" />
   <Import Project="..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets" Condition="Exists('..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets')" />
   <Import Project="..\..\packages\Microsoft.Testing.Platform.1.7.3\build\netstandard2.0\Microsoft.Testing.Platform.targets" Condition="Exists('..\..\packages\Microsoft.Testing.Platform.1.7.3\build\netstandard2.0\Microsoft.Testing.Platform.targets')" />
   <Import Project="..\..\packages\Microsoft.Testing.Platform.MSBuild.1.7.3\build\Microsoft.Testing.Platform.MSBuild.targets" Condition="Exists('..\..\packages\Microsoft.Testing.Platform.MSBuild.1.7.3\build\Microsoft.Testing.Platform.MSBuild.targets')" />
   <Import Project="..\..\packages\MSTest.TestAdapter.3.9.3\build\net462\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.3.9.3\build\net462\MSTest.TestAdapter.targets')" />
-  <Import Project="..\..\packages\Autodesk.DataExchange.7.4.0-beta\build\Autodesk.DataExchange.targets" Condition="Exists('..\..\packages\Autodesk.DataExchange.7.4.0-beta\build\Autodesk.DataExchange.targets')" />
+  <Import Project="..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\build\Autodesk.DataExchange.targets" Condition="Exists('..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\build\Autodesk.DataExchange.targets')" />
 </Project>

--- a/test/ConsoleConnector_Test/ConsoleConnector_Test.csproj
+++ b/test/ConsoleConnector_Test/ConsoleConnector_Test.csproj
@@ -64,8 +64,7 @@
       <HintPath>..\..\packages\AngleSharp.1.2.0\lib\net472\AngleSharp.dll</HintPath>
     </Reference>
     <Reference Include="Autodesk.DataExchange, Version=7.5.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\lib\net48\Autodesk.DataExchange.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Autodesk.DataExchange.7.5.0-beta\lib\net48\Autodesk.DataExchange.dll</HintPath>
     </Reference>
     <Reference Include="Autodesk.GeometryUtilities.PrimitivesAPI, Version=0.9.3.0, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>..\..\packages\Autodesk.DataExchange.GeometryDefinitions.0.9.3\lib\net48\Autodesk.GeometryUtilities.PrimitivesAPI.dll</HintPath>
@@ -458,12 +457,12 @@
     <Error Condition="!Exists('..\..\packages\Microsoft.Testing.Extensions.Telemetry.1.7.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Testing.Extensions.Telemetry.1.7.3\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props'))" />
     <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.3.9.3\build\net462\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.3.9.3\build\net462\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.3.9.3\build\net462\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.3.9.3\build\net462\MSTest.TestAdapter.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\build\Autodesk.DataExchange.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\build\Autodesk.DataExchange.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Autodesk.DataExchange.7.5.0-beta\build\Autodesk.DataExchange.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Autodesk.DataExchange.7.5.0-beta\build\Autodesk.DataExchange.targets'))" />
   </Target>
   <Import Project="..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets" Condition="Exists('..\..\packages\ForgeParameters-csharp_win_release_intel64_v140.3.0.6\build\ForgeParameters-csharp_win_release_intel64_v140.targets')" />
   <Import Project="..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets" Condition="Exists('..\..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets')" />
   <Import Project="..\..\packages\Microsoft.Testing.Platform.1.7.3\build\netstandard2.0\Microsoft.Testing.Platform.targets" Condition="Exists('..\..\packages\Microsoft.Testing.Platform.1.7.3\build\netstandard2.0\Microsoft.Testing.Platform.targets')" />
   <Import Project="..\..\packages\Microsoft.Testing.Platform.MSBuild.1.7.3\build\Microsoft.Testing.Platform.MSBuild.targets" Condition="Exists('..\..\packages\Microsoft.Testing.Platform.MSBuild.1.7.3\build\Microsoft.Testing.Platform.MSBuild.targets')" />
   <Import Project="..\..\packages\MSTest.TestAdapter.3.9.3\build\net462\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.3.9.3\build\net462\MSTest.TestAdapter.targets')" />
-  <Import Project="..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\build\Autodesk.DataExchange.targets" Condition="Exists('..\..\packages\Autodesk.DataExchange.7.5.0-alpha.3\build\Autodesk.DataExchange.targets')" />
+  <Import Project="..\..\packages\Autodesk.DataExchange.7.5.0-beta\build\Autodesk.DataExchange.targets" Condition="Exists('..\..\packages\Autodesk.DataExchange.7.5.0-beta\build\Autodesk.DataExchange.targets')" />
 </Project>

--- a/test/ConsoleConnector_Test/packages.config
+++ b/test/ConsoleConnector_Test/packages.config
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AngleSharp" version="1.2.0" targetFramework="net48" />
-  <package id="Autodesk.DataExchange" version="7.5.0-alpha.3" targetFramework="net48" />
+  <package id="Autodesk.DataExchange" version="7.5.0-beta" targetFramework="net48" />
   <package id="Autodesk.DataExchange.GeometryDefinitions" version="0.9.3" targetFramework="net48" />
   <package id="Autodesk.Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
   <package id="Castle.Core" version="5.1.1" targetFramework="net48" />

--- a/test/ConsoleConnector_Test/packages.config
+++ b/test/ConsoleConnector_Test/packages.config
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AngleSharp" version="1.2.0" targetFramework="net48" />
-  <package id="Autodesk.DataExchange" version="7.4.0-beta" targetFramework="net48" />
-  <package id="Autodesk.DataExchange.GeometryDefinitions" version="0.1.10" targetFramework="net48" />
+  <package id="Autodesk.DataExchange" version="7.5.0-alpha.3" targetFramework="net48" />
+  <package id="Autodesk.DataExchange.GeometryDefinitions" version="0.9.3" targetFramework="net48" />
   <package id="Autodesk.Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
   <package id="Castle.Core" version="5.1.1" targetFramework="net48" />
   <package id="ForgeParameters-csharp_win_release_intel64_v140" version="3.0.6" targetFramework="net48" />


### PR DESCRIPTION
- packages.config + csproj references: Autodesk.DataExchange 7.4.0-beta -> 7.5.0-alpha.3 and Autodesk.DataExchange.GeometryDefinitions 0.1.10 -> 0.9.3 (PrimitivesAPI/MeshAPI 0.9.3.0).
- Migrate Autodesk.GeometryPrimitives.Data[.DX] -> Autodesk.GeometryUtilities.PrimitivesAPI[.DX].
- Remove obsolete client-side Client.GenerateViewableAsync calls (removed in 7.5.0; viewable generation is now handled server-side).